### PR TITLE
docs(README): honest site description (H550)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,58 @@
-gasyoun.github.io
-=================
+# gasyoun.github.io
 
-Creating Pages with the automatic generator
+_Created: 08-10-2014 · Last updated: 11-07-2026_
+
+Personal GitHub Pages site of Mārcis Gasūns ([@gasyoun](https://github.com/gasyoun)),
+served at [gasyoun.github.io](https://gasyoun.github.io/). It hosts a handful of
+static Sanskrit / Vedic lexicographic experiments — not a blog or CV — kept as
+plain HTML and text data.
+
+## What is published here
+
+- **[index.html](https://github.com/gasyoun/gasyoun.github.io/blob/master/index.html)**
+  (~12 MB) — a multilingual Ṛgveda reader. Each stanza is shown as Vedic
+  Devanagari, IAST transliteration, and padapāṭha, alongside the Russian
+  (Elizarenkova), German (Geldner), and English (Griffith) translations, using
+  Indological web fonts served from
+  [fonts/](https://github.com/gasyoun/gasyoun.github.io/tree/master/fonts). The
+  same document also lives under
+  [RV/](https://github.com/gasyoun/gasyoun.github.io/tree/master/RV) with its own
+  [rigveda.css](https://github.com/gasyoun/gasyoun.github.io/blob/master/RV/rigveda.css).
+- **[PWGagainstMW.html](https://github.com/gasyoun/gasyoun.github.io/blob/master/PWGagainstMW.html)**
+  — a comparison of PWG (Petersburger Wörterbuch) headwords against
+  Monier-Williams, grouped by vowel/consonant patterns, each linking into the
+  Cologne [sanskrit-lexicon](https://www.sanskrit-lexicon.uni-koeln.de/) scan
+  viewer.
+- **Reverse-index / reverse-sort outputs** — devanagari-sorted and
+  reverse-sorted word lists derived from headword input:
+  [reverse20-ouput/](https://github.com/gasyoun/gasyoun.github.io/tree/master/reverse20-ouput)
+  (note the misspelled directory name, preserved as published),
+  [reverse21-output/](https://github.com/gasyoun/gasyoun.github.io/tree/master/reverse21-output),
+  and
+  [reverse22-output/](https://github.com/gasyoun/gasyoun.github.io/tree/master/reverse22-output)
+  (with its
+  [input.txt](https://github.com/gasyoun/gasyoun.github.io/blob/master/reverse22-output/input.txt)).
+- **[296.txt](https://github.com/gasyoun/gasyoun.github.io/blob/master/296.txt)**
+  and
+  **[296-SLP1.txt](https://github.com/gasyoun/gasyoun.github.io/blob/master/296-SLP1.txt)**
+  — a 295-line reverse word-to-page index of a Sanskrit text, in raw and SLP1
+  transliteration.
+
+## Leftover scaffolding
+
+[index2.html](https://github.com/gasyoun/gasyoun.github.io/blob/master/index2.html)
+and
+[params.json](https://github.com/gasyoun/gasyoun.github.io/blob/master/params.json)
+are the original GitHub Pages "automatic generator" (Merlot theme) template
+files, kept as-is; the served landing page is `index.html`, not `index2.html`.
+
+## Maintenance
+
+The only automation in the repo is Dependabot
+([.github/dependabot.yml](https://github.com/gasyoun/gasyoun.github.io/blob/master/.github/dependabot.yml))
+with a
+[Dependabot auto-merge workflow](https://github.com/gasyoun/gasyoun.github.io/blob/master/.github/workflows/dependabot-auto-merge.yml).
+There is no build step: GitHub Pages serves the static files directly from the
+`master` branch.
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
Part of handoff [H550](https://github.com/gasyoun/Uprava/blob/main/handoffs/H550-Opus_Uprava_readme-refresh-research-repos_10.07.26.md) (README audit+refactor across research + product repos).

## What changed

The previous `README.md` was the leftover GitHub Pages "automatic generator" boilerplate ("Creating Pages with the automatic generator") — it described nothing about the actual site. Rewritten so every claim is currently true, from inspecting the tracked files:

- **[index.html](https://github.com/gasyoun/gasyoun.github.io/blob/master/index.html)** / **[RV/](https://github.com/gasyoun/gasyoun.github.io/tree/master/RV)** — multilingual Ṛgveda reader (Devanagari, IAST, padapāṭha + Elizarenkova RU, Geldner DE, Griffith EN).
- **[PWGagainstMW.html](https://github.com/gasyoun/gasyoun.github.io/blob/master/PWGagainstMW.html)** — PWG-vs-Monier-Williams headword comparison linking into the Cologne scan viewer.
- **reverse20-ouput / reverse21-output / reverse22-output** — devanagari-sorted & reverse-sorted word lists.
- **[296.txt](https://github.com/gasyoun/gasyoun.github.io/blob/master/296.txt)** / **296-SLP1.txt** — 295-line reverse word-to-page index.
- Notes the `index2.html` + `params.json` generator scaffold and the Dependabot-only automation.

Applied org Markdown conventions: dated header (real creation date 08-10-2014 from the GitHub API `created_at`, since the local clone is shallow), byline, full blob/tree URLs, no raw HTML. No MANUAL markers or readme-guard present to preserve.

Verified local HEAD == API HEAD (`26f6a8e`) before branching; working tree was clean; no concurrent "best-standard" README commit found on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)