### PR TITLE
vote: re-cut the 320 with Save-to-GitHub + V17 ergonomics (H3105)

### DIFF
--- a/vote/sheets/h215_gold_full_320.html
+++ b/vote/sheets/h215_gold_full_320.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 32 packs</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;

--- a/vote/sheets/h215_gold_full_320/pack-01.html
+++ b/vote/sheets/h215_gold_full_320/pack-01.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:bb9e1aa0abb1…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:7bb76f5957dc…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:bb9e1aa0abb17577b76d9ab04771362d0d81d4e7b595af2af30742552aa8a18b";
+  var CONTENT_HASH = "sha256:7bb76f5957dc33bfc2c2259a87131ce1538214bba9884378eda6401bf1c4c8a9";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["5", "3", "6", "9", "4", "2", "0", "1", "10", "7"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 1, "pack_name": "01", "packs": 32, "enabled": true};
+  var CARD_Q = {"5": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "3": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "6": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "9": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "4": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "2": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "0": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "1": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "10": "Верен ли ярлык LLM «wrong-sense» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "7": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-02.html
+++ b/vote/sheets/h215_gold_full_320/pack-02.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:9d066e397856…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:786fc11e9f97…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:9d066e3978561412b34d68749706b9381555e6185022b59112d6cb7b3fcaa9c0";
+  var CONTENT_HASH = "sha256:786fc11e9f97b1f30ba4ff3be58122dfb3473bdf8b3cd48c57e3a38d2b6b7e7f";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["18", "15", "22", "11", "8", "20", "41", "13", "23", "19"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 2, "pack_name": "02", "packs": 32, "enabled": true};
+  var CARD_Q = {"18": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "15": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "22": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "11": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "8": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "20": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "41": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "13": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "23": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "19": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-03.html
+++ b/vote/sheets/h215_gold_full_320/pack-03.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:9ec50b7ed97f…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:6968131114bd…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:9ec50b7ed97fe23193b232840c3d527a918c3aea1f66da0f2d3e76e21c067368";
+  var CONTENT_HASH = "sha256:6968131114bd9b78eca40e0f78b355916277600d234556faa9a3120e8b6dc579";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["24", "17", "12", "29", "44", "16", "31", "21", "54", "35"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 3, "pack_name": "03", "packs": 32, "enabled": true};
+  var CARD_Q = {"24": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "17": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "12": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "29": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "44": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "16": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "31": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "21": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "54": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "35": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-04.html
+++ b/vote/sheets/h215_gold_full_320/pack-04.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:23756c4659dc…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:09bd5402f583…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:23756c4659dc593c1ca57e4aa12527764eae25a5a5339648028e4aace1c6589c";
+  var CONTENT_HASH = "sha256:09bd5402f583c3ce4731d7ba11ac5403ab7b4c0e6c723f045ad74811343ece13";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["14", "37", "51", "27", "32", "25", "58", "48", "30", "47"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 4, "pack_name": "04", "packs": 32, "enabled": true};
+  var CARD_Q = {"14": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "37": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "51": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "27": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "32": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "25": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "58": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "48": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "30": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "47": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-05.html
+++ b/vote/sheets/h215_gold_full_320/pack-05.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:ec3f0038a497…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:ae92bcf26ea0…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:ec3f0038a497741857d7f3aaf4a927c95ef0cabbc4e6d43c5af4758481629946";
+  var CONTENT_HASH = "sha256:ae92bcf26ea0041d1e0512516e1e0aaa39f4d1a331872af1f4204ded96c9ebfc";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["73", "39", "33", "26", "59", "52", "34", "50", "74", "42"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 5, "pack_name": "05", "packs": 32, "enabled": true};
+  var CARD_Q = {"73": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "39": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "33": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "26": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "59": "Верен ли ярлык LLM «hallucinated» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "52": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "34": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "50": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "74": "Верен ли ярлык LLM «wrong-sense» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "42": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-06.html
+++ b/vote/sheets/h215_gold_full_320/pack-06.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:7ff625782e30…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:4e1bf0156e59…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:7ff625782e307fa6585b68e80d37cff669b15e1597f66f45518adc4e737de8e6";
+  var CONTENT_HASH = "sha256:4e1bf0156e59259489c166a7c1e5dcc8f6aed40d71a284f9eede0eae86a0c01d";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["46", "28", "65", "69", "38", "55", "75", "60", "56", "36"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 6, "pack_name": "06", "packs": 32, "enabled": true};
+  var CARD_Q = {"46": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "28": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "65": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "69": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "38": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "55": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "75": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "60": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "56": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "36": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-07.html
+++ b/vote/sheets/h215_gold_full_320/pack-07.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:b37180529c86…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:ce03679ff3f6…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:b37180529c8631d036e6e2eb9753c6beaf1b6c023877f3eb47469a51be70f90e";
+  var CONTENT_HASH = "sha256:ce03679ff3f6cd9ee65ff1fa1e187ca90a20d99024e6718e76cd322144284b79";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["66", "77", "40", "71", "76", "81", "57", "43", "68", "86"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 7, "pack_name": "07", "packs": 32, "enabled": true};
+  var CARD_Q = {"66": "Верен ли ярлык LLM «wrong-sense» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "77": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "40": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "71": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "76": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "81": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "57": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "43": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "68": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "86": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-08.html
+++ b/vote/sheets/h215_gold_full_320/pack-08.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:eb988a1f8284…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:bf8756c177f3…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:eb988a1f828400804471c107e97d27b664933d508fa865d9a5ed13f36b277b2b";
+  var CONTENT_HASH = "sha256:bf8756c177f316c21ecb8a6fe760ca413d30cb7924060da0f14aff0f5c66ab5f";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["45", "91", "79", "98", "61", "53", "78", "93", "49", "113"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 8, "pack_name": "08", "packs": 32, "enabled": true};
+  var CARD_Q = {"45": "Верен ли ярлык LLM «wrong-sense» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "91": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "79": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "98": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "61": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "53": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "78": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "93": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "49": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "113": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-09.html
+++ b/vote/sheets/h215_gold_full_320/pack-09.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:bdd7566450ed…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:cd982d50d9ac…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:bdd7566450edbacba97cc309114fd4eab5debf5733141f3c7219b4776de22117";
+  var CONTENT_HASH = "sha256:cd982d50d9ac7db5332de230b8f24e0560d4ab75833a452c23481c57e429c7d4";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["88", "99", "67", "63", "84", "104", "62", "115", "103", "101"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 9, "pack_name": "09", "packs": 32, "enabled": true};
+  var CARD_Q = {"88": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "99": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "67": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "63": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "84": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "104": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "62": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "115": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "103": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "101": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-10.html
+++ b/vote/sheets/h215_gold_full_320/pack-10.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:3b458a691e6f…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:c0eefdedc6b9…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:3b458a691e6fe272f333da308fa9d017c9daaf4329dd1a03261dbd22aaae52fc";
+  var CONTENT_HASH = "sha256:c0eefdedc6b9b97d04e753090f23414044b69d32c1f0f2b03399fc0f224e9bdc";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["83", "70", "89", "107", "64", "116", "112", "110", "85", "82"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 10, "pack_name": "10", "packs": 32, "enabled": true};
+  var CARD_Q = {"83": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "70": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "89": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "107": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "64": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "116": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "112": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "110": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "85": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "82": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-11.html
+++ b/vote/sheets/h215_gold_full_320/pack-11.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:1eb8290aa151…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:a8cfc81b2416…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:1eb8290aa1515d2717d13677cd1fc33729caa53c1b0890e557c54e72e5cffc67";
+  var CONTENT_HASH = "sha256:a8cfc81b241627177f6881c3b120c11afe9401a68b5d5281c1871a8bf20db19d";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["102", "109", "72", "117", "118", "128", "92", "87", "105", "120"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 11, "pack_name": "11", "packs": 32, "enabled": true};
+  var CARD_Q = {"102": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "109": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "72": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "117": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "118": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "128": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "92": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "87": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "105": "Верен ли ярлык LLM «wrong-sense» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "120": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-12.html
+++ b/vote/sheets/h215_gold_full_320/pack-12.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:3736d0d4998d…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:8a7a013baa6e…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:3736d0d4998dec3363e0dc7b5a7937c5816dc1617c810ea55abb3a4cdbd851d5";
+  var CONTENT_HASH = "sha256:8a7a013baa6e976da0f14fcb44323517c64ba0436168c756b44929096afd60f7";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["80", "122", "119", "135", "97", "90", "111", "121", "94", "123"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 12, "pack_name": "12", "packs": 32, "enabled": true};
+  var CARD_Q = {"80": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "122": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "119": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "135": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "97": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "90": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "111": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "121": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "94": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "123": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-13.html
+++ b/vote/sheets/h215_gold_full_320/pack-13.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:ec79679a3c74…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:1cb01b0d83b0…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:ec79679a3c747106125c9f64f2209946665cbc341c4f43b069302647036d1e34";
+  var CONTENT_HASH = "sha256:1cb01b0d83b0bcc3b650db3271032e1febbdb8969a0dc6a49219a16bb1994a40";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["129", "140", "100", "96", "124", "133", "95", "136", "156", "141"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 13, "pack_name": "13", "packs": 32, "enabled": true};
+  var CARD_Q = {"129": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "140": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "100": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "96": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "124": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "133": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "95": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "136": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "156": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "141": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-14.html
+++ b/vote/sheets/h215_gold_full_320/pack-14.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:29c270e133cb…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:9c4d538838a5…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:29c270e133cb9a90002f683749b42c97fed3c1477d22fac2ea1f692fbce99fec";
+  var CONTENT_HASH = "sha256:9c4d538838a5213c49797fff43be097eb26d69eb49acf5b9a5abfe829e5515f4";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["106", "108", "126", "134", "125", "144", "163", "154", "114", "130"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 14, "pack_name": "14", "packs": 32, "enabled": true};
+  var CARD_Q = {"106": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "108": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "126": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "134": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "125": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "144": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "163": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "154": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "114": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "130": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-15.html
+++ b/vote/sheets/h215_gold_full_320/pack-15.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:51ec6a4679f9…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:23999e0bb73e…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:51ec6a4679f9edb04f2a288dd443fb8621933ccd5b2131341569dc5ef26c076d";
+  var CONTENT_HASH = "sha256:23999e0bb73e12c13bf4b9f6bd9a2c54e4c29955c17b3b68874de09dd13ffd0b";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["150", "137", "127", "155", "179", "164", "142", "131", "153", "139"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 15, "pack_name": "15", "packs": 32, "enabled": true};
+  var CARD_Q = {"150": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "137": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "127": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "155": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "179": "Верен ли ярлык LLM «hallucinated» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "164": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "142": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "131": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "153": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "139": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-16.html
+++ b/vote/sheets/h215_gold_full_320/pack-16.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:b422de1ab948…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:467c0bb40351…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:b422de1ab948406a2fd8cc105057945b04b512566d098c2ca00cb7e9306c5d9f";
+  var CONTENT_HASH = "sha256:467c0bb403510b7a990f9e5bcaf20baf4808a90f592fa4a9d79af3d785ad9b25";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["132", "174", "188", "167", "147", "143", "157", "149", "138", "176"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 16, "pack_name": "16", "packs": 32, "enabled": true};
+  var CARD_Q = {"132": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "174": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "188": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "167": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "147": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "143": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "157": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "149": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "138": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "176": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-17.html
+++ b/vote/sheets/h215_gold_full_320/pack-17.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:9eb95226eb70…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:178a70c022c1…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:9eb95226eb70408a5d10f03572ec5a6e3456374e8a55ee12a8bf7492fd74fdbf";
+  var CONTENT_HASH = "sha256:178a70c022c1cd1e0bc221f793cf6c20dad71eb561aefffaa4c3dafec692bae5";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["193", "169", "148", "145", "159", "171", "146", "196", "199", "170"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 17, "pack_name": "17", "packs": 32, "enabled": true};
+  var CARD_Q = {"193": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "169": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "148": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "145": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "159": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "171": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "146": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "196": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "199": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "170": "Верен ли ярлык LLM «wrong-sense» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-18.html
+++ b/vote/sheets/h215_gold_full_320/pack-18.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:524c5f196e43…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:4ae617de6129…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:524c5f196e431120a9f1af599cd0378aba225d326cf95cfddd48de1e0be1be6b";
+  var CONTENT_HASH = "sha256:4ae617de6129663ed5eb0d856121cacbdfe8cea9b9fdfd808c67a4a0ce49b409";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["165", "152", "161", "177", "151", "212", "209", "175", "166", "158"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 18, "pack_name": "18", "packs": 32, "enabled": true};
+  var CARD_Q = {"165": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "152": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "161": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "177": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "151": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "212": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "209": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "175": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "166": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "158": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-19.html
+++ b/vote/sheets/h215_gold_full_320/pack-19.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:b0568a134c1f…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:d7ae03395ddb…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:b0568a134c1f727d50e4e034d43333d37836186085e368c18c1d53be8027fb60";
+  var CONTENT_HASH = "sha256:d7ae03395ddbae253572d8aab8e72177cb7690341206b02a936348d838b0e62d";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["162", "183", "182", "229", "210", "181", "172", "160", "168", "185"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 19, "pack_name": "19", "packs": 32, "enabled": true};
+  var CARD_Q = {"162": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "183": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "182": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "229": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "210": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "181": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "172": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "160": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "168": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "185": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-20.html
+++ b/vote/sheets/h215_gold_full_320/pack-20.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:806be31e3416…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:dd70b1245f7f…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:806be31e3416cb5edd22e21a95846e20e143b120fbafc23086f5423d90f60fd1";
+  var CONTENT_HASH = "sha256:dd70b1245f7fc036b79c0e8193a3b362329c5618901d2428fbedac05aabb3357";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["197", "230", "217", "190", "173", "195", "180", "186", "203", "265"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 20, "pack_name": "20", "packs": 32, "enabled": true};
+  var CARD_Q = {"197": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "230": "Верен ли ярлык LLM «wrong-sense» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "217": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "190": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "173": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "195": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "180": "Верен ли ярлык LLM «wrong-sense» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "186": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "203": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "265": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-21.html
+++ b/vote/sheets/h215_gold_full_320/pack-21.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:f5f9651e7609…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:c02615c6b9c7…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:f5f9651e7609004b929edd9f66263013c2fb593763bf614e3d5ceee8a499696f";
+  var CONTENT_HASH = "sha256:c02615c6b9c72970092524d13c280cf5e2267bea7dc4d986df5d133136664a33";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["219", "192", "178", "214", "184", "191", "218", "266", "221", "201"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 21, "pack_name": "21", "packs": 32, "enabled": true};
+  var CARD_Q = {"219": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "192": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "178": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "214": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "184": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "191": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "218": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "266": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "221": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "201": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-22.html
+++ b/vote/sheets/h215_gold_full_320/pack-22.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:d6551d294c61…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:aafba674be79…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:d6551d294c61e8c57b472b38ee44ffcf56a31931003ee71e3e6ba4f268086324";
+  var CONTENT_HASH = "sha256:aafba674be795948557d85b5f3d3f1deb1fa8ed646d7dc3da286a3adf9ad4016";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["189", "224", "187", "205", "225", "269", "222", "208", "198", "227"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 22, "pack_name": "22", "packs": 32, "enabled": true};
+  var CARD_Q = {"189": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "224": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "187": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "205": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "225": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "269": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "222": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "208": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "198": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "227": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-23.html
+++ b/vote/sheets/h215_gold_full_320/pack-23.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:3dd88e5d24d7…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:c9fa1fa97c7c…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:3dd88e5d24d7b4547c97a47a396cf002ceaa367819596b7a45ef8d47ac1dda9c";
+  var CONTENT_HASH = "sha256:c9fa1fa97c7c9e4fedc5c4a736ad289c60865fbf9a07d12c23ede22611a320c0";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["194", "206", "231", "273", "223", "238", "204", "249", "200", "213"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 23, "pack_name": "23", "packs": 32, "enabled": true};
+  var CARD_Q = {"194": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "206": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "231": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "273": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "223": "Верен ли ярлык LLM «hallucinated» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "238": "Верен ли ярлык LLM «wrong-sense» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "204": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "249": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "200": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "213": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-24.html
+++ b/vote/sheets/h215_gold_full_320/pack-24.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:8fc1b2a0da54…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:2536744e5460…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:8fc1b2a0da54a81270b9b227dc706565c1e34be30a70c51502ea62bb3d15504f";
+  var CONTENT_HASH = "sha256:2536744e546063b5ac6ed1ab41dc9ad945cde5b5a4a43af373de6e90a077df8f";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["241", "275", "233", "247", "207", "257", "202", "216", "248", "276"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 24, "pack_name": "24", "packs": 32, "enabled": true};
+  var CARD_Q = {"241": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "275": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "233": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "247": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "207": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "257": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "202": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "216": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "248": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "276": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-25.html
+++ b/vote/sheets/h215_gold_full_320/pack-25.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:f88b1604a08f…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:ff7b60e4e6f2…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:f88b1604a08f02bc6ba2705432dc2ab87a39d2920406d9c0058a533a4db05e3f";
+  var CONTENT_HASH = "sha256:ff7b60e4e6f238860ed7f4a5ff2ceb26c99df1e367b53708bf7c42f4a79d47a6";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["236", "254", "211", "258", "220", "239", "250", "280", "237", "259"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 25, "pack_name": "25", "packs": 32, "enabled": true};
+  var CARD_Q = {"236": "Верен ли ярлык LLM «hallucinated» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "254": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "211": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "258": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "220": "Верен ли ярлык LLM «hallucinated» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "239": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "250": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "280": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "237": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "259": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-26.html
+++ b/vote/sheets/h215_gold_full_320/pack-26.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:e90c6ec57ef3…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:3841ec848e29…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:e90c6ec57ef327c79971e460e7a1323327648bb483695b310b6befee22dd3ccd";
+  var CONTENT_HASH = "sha256:3841ec848e294ab7baf36dcf4c166113cb944368d6c3a96872d48b0dc7c67466";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["215", "267", "226", "244", "253", "282", "242", "260", "228", "270"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 26, "pack_name": "26", "packs": 32, "enabled": true};
+  var CARD_Q = {"215": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "267": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "226": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "244": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "253": "Верен ли ярлык LLM «hallucinated» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "282": "Верен ли ярлык LLM «wrong-sense» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "242": "Верен ли ярлык LLM «hallucinated» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "260": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "228": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "270": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-27.html
+++ b/vote/sheets/h215_gold_full_320/pack-27.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:4f88bb3a9344…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:9cc5a9c2e617…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:4f88bb3a93444de7c1cf33aabe77b5c2063ab9e41a6e2b1e3c2e37931019a1cf";
+  var CONTENT_HASH = "sha256:9cc5a9c2e6171bdd6ddac5c8f1b7df1b4535288e83972c469a55d32ac50afdc5";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["232", "245", "262", "285", "243", "261", "235", "272", "234", "246"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 27, "pack_name": "27", "packs": 32, "enabled": true};
+  var CARD_Q = {"232": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "245": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "262": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "285": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "243": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "261": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "235": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "272": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "234": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "246": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-28.html
+++ b/vote/sheets/h215_gold_full_320/pack-28.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:357502e8190a…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:4b7d76a128b2…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:357502e8190a6a403db56fcc085e269c235829ed4dbec9edcedfdf4cd35d04ae";
+  var CONTENT_HASH = "sha256:4b7d76a128b2e75e521773d556301e6c0451f30030835681bd2d4edaeef9b2c4";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["277", "297", "283", "263", "240", "287", "252", "251", "279", "298"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 28, "pack_name": "28", "packs": 32, "enabled": true};
+  var CARD_Q = {"277": "Верен ли ярлык LLM «hallucinated» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "297": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "283": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "263": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "240": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "287": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "252": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "251": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "279": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "298": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-29.html
+++ b/vote/sheets/h215_gold_full_320/pack-29.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:7e90cfc88782…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:bdbc934699d7…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:7e90cfc88782edb6fe45b274579fbf98681728cad65a632d14a66a43a9955604";
+  var CONTENT_HASH = "sha256:bdbc934699d7d18c2838e0105f9794e499aefe64cc9da434a282bbbf7e1b8d0d";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["284", "264", "256", "290", "255", "268", "296", "300", "301", "281"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 29, "pack_name": "29", "packs": 32, "enabled": true};
+  var CARD_Q = {"284": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "264": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "256": "Верен ли ярлык LLM «hallucinated» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "290": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "255": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "268": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "296": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "300": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "301": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "281": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-30.html
+++ b/vote/sheets/h215_gold_full_320/pack-30.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:35e00b8daa28…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:5cab47168f8c…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:35e00b8daa2849368621a97c10ca635cd1f475e208ff9a37f938b129c766ecaf";
+  var CONTENT_HASH = "sha256:5cab47168f8cdc7fe61d9fc570321ae5ba9acb0691d03ab752b367b502499a26";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["278", "291", "271", "286", "313", "302", "308", "288", "293", "294"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 30, "pack_name": "30", "packs": 32, "enabled": true};
+  var CARD_Q = {"278": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "291": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "271": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "286": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "313": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "302": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "308": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "288": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "293": "Верен ли ярлык LLM «wrong-sense» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "294": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-31.html
+++ b/vote/sheets/h215_gold_full_320/pack-31.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:570433d9fae0…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:8b515ff42efa…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:570433d9fae0c09a801fd1bb136e19dc2fab12720f00fcf93706d0dad0095a13";
+  var CONTENT_HASH = "sha256:8b515ff42efa1a946ed10d5588d988138dc7b11bf410709c34e6953a1e7dfff7";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["274", "289", "316", "304", "310", "305", "311", "303", "292", "299"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 31, "pack_name": "31", "packs": 32, "enabled": true};
+  var CARD_Q = {"274": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "289": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "316": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "304": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "310": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "305": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "311": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "303": "Верен ли ярлык LLM «lemma-variant» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "292": "Верен ли ярлык LLM «proper-name» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "299": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>

--- a/vote/sheets/h215_gold_full_320/pack-32.html
+++ b/vote/sheets/h215_gold_full_320/pack-32.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="dark">
-<meta name="generator" content="csl-pyutil/0.19.1">
+<meta name="generator" content="csl-pyutil/0.21.0">
 <title>G6 · золотой стандарт — стартовый лист MQM — 10 items</title>
 <style>
   :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
@@ -135,13 +135,32 @@
                padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
                opacity:0; pointer-events:none; transition:opacity .18s; }
   .flowtoast.on { opacity:1; }
+  .dl.inbox { background:#2d6a4f; }
+  .dl.inbox[disabled] { background:var(--panel2); color:var(--muted); cursor:not-allowed; border:1px solid var(--border); }
+  .inboxnote { color:var(--muted); font-size:12px; }
+  .inboxcode { font-family:ui-monospace,Consolas,monospace; font-size:16px; letter-spacing:.12em;
+               background:#11141a; border:1px solid var(--border); border-radius:6px; padding:4px 10px; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
 </style>
 </head>
 <body>
 <header class="top">
   <div>
     <h1>G6 · золотой стандарт — стартовый лист MQM — 10 items</h1>
-    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:d7bbbbf98255…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
+    <div class="sub">Generated 2026-08-14 &middot; sheet_id <code>h215-gold-full-320-2026-08-14</code> &middot; bound <code class="bindchip" title="content_hash — binds this sheet's decisions.json export to exactly this HTML">sha256:0af200c041de…</code> &middot; 320 карточек из gold/gold_set.jsonl (320), стратификация period × kind; типология из 6 ярлыков; каждая карточка несёт словарь, корень и контексты ДО голоса</div>
   </div>
   <div class="tally" id="tally">
     <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
@@ -151,17 +170,18 @@
     <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
     <span class="unvoted">&#9711; <span class="count" id="c-unvoted">10</span></span>
   </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
 </header>
 <aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 0</span> · <span class="sc-b">dataset lookup 320</span> · <span class="sc-c">agent adjudication 320</span> (total screened 640). Human cards: <span class="sc-d">320</span>. Evidence: <code>RussianTranslation/gold/HUMAN_GOLD_PROTOCOL.md</code>. Rules: mqm-6-label-typology, h1801-evidence-before-label, h1802-reject-label-picker.</aside>
 <div class="savebanner">&#128229; Your export downloads as <code>h215-gold-full-320-2026-08-14_decisions.json</code> &rarr; save it to <code>RussianTranslation\review\h215-gold-full-320-2026-08-14_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>h215-gold-full-320-2026-08-14</code> — that is how a later session knows which sheet these decisions belong to).</div>
 <div class="toolbar">
-  <button class="dl" id="downloadBtn">Download decisions.json</button><button class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
-  <label id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" type="button" class="dl inbox" id="inboxBtn" title="push this pack's ids and verdicts to the public vote inbox">Save to GitHub</button><span data-submit="1" class="inboxnote" id="inboxNote" role="status"></span><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <label data-submit="1" id="strictReviewerWrap" style="display:flex;align-items:center;gap:6px;font-size:13px">
     Reviewer <input id="strictReviewer" type="text" autocomplete="name" style="background:#11141a;color:var(--text);border:1px solid var(--border);border-radius:6px;padding:7px 9px" />
   </label>
-  <span id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
+  <span data-submit="1" id="strictReviewError" role="alert" style="color:var(--bad);font-size:12px"></span>
   <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
-  <button type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
   <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
   <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="Classical">Classical</button><button data-filter="Epic / early-Classical">Epic / early-Classical</button><button data-filter="Medieval">Medieval</button><button data-filter="Vedic">Vedic</button><button data-filter="unvoted">unvoted only</button></div>
 </div>
@@ -307,6 +327,7 @@
     <textarea class="note" placeholder="необязательный комментарий к решению"></textarea>
   </section>
 </main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
 <footer class="hint">Approve = ярлык LLM верен · Reject = неверен (выберите правильный ярлык из списка) · Defer = на адjudication. Экспорт валидируется против review/locks/h215-gold-full-320-2026-08-14.lock.json. Keyboard: <kbd>a</kbd> Label верен &middot; <kbd>r</kbd> Label неверен
   &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
   this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
@@ -320,7 +341,7 @@
 <script>
 (function () {
   var SHEET_ID = "h215-gold-full-320-2026-08-14";
-  var CONTENT_HASH = "sha256:d7bbbbf98255a63a9d27b65652a5a59a80a61f2c2b71dff2a47a3815c577b829";
+  var CONTENT_HASH = "sha256:0af200c041de9fa213aab99858a2dd118dc048c503306e1952e0200070edf806";
   var STORE_KEY = 'review-sheet:' + SHEET_ID;
   var GENERATED = "2026-08-14";
   var ids = ["317", "309", "314", "312", "315", "307", "295", "306", "318", "319"];
@@ -396,8 +417,8 @@
     if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
     else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
     else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
-    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
-    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'center'}); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
     else return;
     e.preventDefault();
   });
@@ -732,7 +753,7 @@
     var card = __flowCardById(last.id);
     if (card) {
       applyCardUI(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
       var at = __flowIdxOf(last.id);
       if (at !== -1) activeIdx = at;
       __flowPaint();
@@ -754,7 +775,7 @@
     var at = __flowFirstUndecided();
     if (at === -1) { __flowPaint(); return; }
     activeIdx = at;
-    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
     __flowPaint();
   }
   function __flowDecided() {
@@ -815,10 +836,231 @@
     if (at === -1) return;
     var vis = visibleCards();
     activeIdx = at;
-    vis[at].scrollIntoView({ block: 'center' });
+    vis[at].scrollIntoView({ block: 'start' });
     __flowPaint();
     __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
   })();
+
+  var INBOX = {"repo": "gasyoun/vote-inbox", "branch": "", "client_id": "Ov23lifQmcuDYuTw0ZWv", "device_url": "https://kosha.193.232.229.92.sslip.io/gh-device", "pack": 32, "pack_name": "32", "packs": 32, "enabled": true};
+  var CARD_Q = {"317": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "309": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "314": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "312": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "315": "Верен ли ярлык LLM «wrong-sense» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "307": "Верен ли ярлык LLM «partial» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "295": "Верен ли ярлык LLM «wrong-sense» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "306": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "318": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)", "319": "Верен ли ярлык LLM «correct» для этого перевода? (reject → выберите правильный ярлык из списка ниже)"};
+  var INBOX_PULLING = 'pulling votes from GitHub…';
+  var INBOX_HYDRATED = 'pulled {n} vote(s) from GitHub';
+  var INBOX_SAVED = 'saved pack {pack} to GitHub';
+  var INBOX_DISABLED = 'no OAuth client_id / device relay configured — use Download decisions.json';
+  var INBOX_CODE = 'open {url} and enter code {code}';
+  var INBOX_FAILED = 'GitHub save failed: {why}';
+  var __inboxBtn = document.getElementById('inboxBtn');
+  var __inboxNote = document.getElementById('inboxNote');
+  function __inboxSay(msg) { if (__inboxNote) __inboxNote.textContent = msg; }
+  function __inboxDir() {
+    return 'https://api.github.com/repos/' + INBOX.repo + '/contents/decisions/'
+      + encodeURIComponent(SHEET_ID);
+  }
+  // A public repo must not become a back door onto the card text. A note ships
+  // only when it is short, carries no markup, and is not the card's own question
+  // pasted back — otherwise the decision travels alone.
+  function __inboxNoteOk(id, note) {
+    if (!note) return false;
+    if (note.length > 280) return false;
+    if (note.indexOf('<') >= 0) return false;
+    var q = CARD_Q[id];
+    if (q && q.length > 12 && note.indexOf(q) >= 0) return false;
+    return true;
+  }
+  function __inboxPayload() {
+    var base = JSON.parse(exportPayload());
+    return { sheet_id: base.sheet_id, pack: INBOX.pack, generated: base.generated,
+             decided: base.decided,
+             items: base.items.map(function (it) {
+               var out = { id: it.id, decision: it.decision };
+               if (__inboxNoteOk(it.id, it.note)) out.note = it.note;
+               return out;
+             }) };
+  }
+  // The pull is two network hops, and the second one -- raw.githubusercontent.com,
+  // once per decisions file -- is routinely slow to settle, sometimes past 10 s,
+  // while the api.github.com listing answers in about one. Measured 18-08-2026: the
+  // first hydrate smoke FAILED on a 20 s ceiling against completely correct code.
+  // Without a hint the reviewer sees an unvoted sheet that silently fills in later,
+  // which reads as a bug and invites them to start voting over the top of votes that
+  // are about to arrive. So say so while it is happening, and clear the line if the
+  // pull turns out to bring nothing.
+  function __inboxHydrate() {
+    var said = false;
+    function announce() { if (!said) { said = true; __inboxSay(INBOX_PULLING); } }
+    function done(merged) {
+      if (merged) { __inboxSay(INBOX_HYDRATED.replace('{n}', merged)); return; }
+      if (said) __inboxSay('');
+    }
+    announce();
+    fetch(__inboxDir()).then(function (r) { return r.ok ? r.json() : []; }).then(function (list) {
+      if (!Array.isArray(list) || !list.length) { done(0); return; }
+      var files = list.filter(function (f) { return /\.json$/.test(f.name || ''); });
+      var pending = files.length, merged = 0;
+      if (!pending) { done(0); return; }
+      files.forEach(function (f) {
+        fetch(f.download_url).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (doc) {
+            if (!doc || !doc.items) return;
+            doc.items.forEach(function (it) {
+              if (!it.decision || ids.indexOf(it.id) < 0) return;
+              // Two machines, one sheet: the inbox is the shared record, so it wins.
+              state[it.id] = state[it.id] || {};
+              if (state[it.id].decision !== it.decision) merged++;
+              state[it.id].decision = it.decision;
+            });
+          })
+          .catch(function () {})
+          .then(function () {
+            if (--pending > 0) return;
+            if (merged) {
+              save();
+              document.querySelectorAll('.card').forEach(function (c) { applyCardUI(c); });
+            }
+            done(merged);
+          });
+      });
+    }).catch(function () { done(0); });
+  }
+  function __inboxPut(token) {
+    var path = 'decisions/' + encodeURIComponent(SHEET_ID) + '/pack-' + INBOX.pack_name + '.json';
+    var url = 'https://api.github.com/repos/' + INBOX.repo + '/contents/' + path;
+    var body = JSON.stringify(__inboxPayload(), null, 2);
+    var enc = btoa(unescape(encodeURIComponent(body)));
+    function send(sha) {
+      var msg = { message: 'vote: ' + SHEET_ID + ' pack-' + INBOX.pack_name,
+                  content: enc };
+      // No branch unless the caller named one: the contents API then writes to the
+      // repo's OWN default branch. Defaulting to 'main' here shipped a bug in
+      // 0.17.0 — gasyoun/vote-inbox defaults to `master`, so the first real save
+      // would have 404'd on a branch that does not exist.
+      if (INBOX.branch) msg.branch = INBOX.branch;
+      if (sha) msg.sha = sha;
+      return fetch(url, { method:'PUT',
+        headers: { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json',
+                   'Accept': 'application/vnd.github+json' },
+        body: JSON.stringify(msg) });
+    }
+    return fetch(url + (INBOX.branch ? '?ref=' + encodeURIComponent(INBOX.branch) : ''),
+                 { headers: { 'Authorization': 'Bearer ' + token } })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (cur) { return send(cur && cur.sha); })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        __inboxSay(INBOX_SAVED.replace('{pack}', INBOX.pack_name));
+      });
+  }
+  // GitHub does not send Access-Control-Allow-Origin on login/device/* (measured
+  // 18-08-2026), so this exchange cannot go straight to github.com from a page.
+  // INBOX.device_url must name a relay that forwards and echoes CORS headers.
+  function __inboxDeviceToken() {
+    var base = INBOX.device_url.replace(/\/$/, '');
+    return fetch(base + '/code', { method:'POST',
+        headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+        body: JSON.stringify({ client_id: INBOX.client_id, scope: 'public_repo' }) })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (d) {
+        __inboxSay(INBOX_CODE.replace('{url}', d.verification_uri).replace('{code}', d.user_code));
+        var iv = Math.max(5, d.interval || 5) * 1000, deadline = Date.now() + (d.expires_in || 900) * 1000;
+        return new Promise(function (resolve, reject) {
+          (function poll() {
+            if (Date.now() > deadline) { reject(new Error('expired')); return; }
+            setTimeout(function () {
+              fetch(base + '/token', { method:'POST',
+                  headers: { 'Content-Type':'application/json', 'Accept':'application/json' },
+                  body: JSON.stringify({ client_id: INBOX.client_id, device_code: d.device_code,
+                    grant_type: 'urn:ietf:params:oauth:grant-type:device_code' }) })
+                .then(function (r) { return r.json(); })
+                .then(function (t) {
+                  if (t.access_token) { resolve(t.access_token); return; }
+                  if (t.error === 'authorization_pending' || t.error === 'slow_down') { poll(); return; }
+                  reject(new Error(t.error || 'device flow refused'));
+                })
+                .catch(reject);
+            }, iv);
+          })();
+        });
+      });
+  }
+  if (__inboxBtn) {
+    if (!INBOX.enabled) {
+      __inboxBtn.disabled = true;
+      __inboxSay(INBOX_DISABLED);
+    } else {
+      __inboxBtn.addEventListener('click', function () {
+        __inboxBtn.disabled = true;
+        __inboxDeviceToken()
+          .then(__inboxPut)
+          .catch(function (e) { __inboxSay(INBOX_FAILED.replace('{why}', e && e.message ? e.message : e)); })
+          .then(function () { __inboxBtn.disabled = false; });
+      });
+    }
+  }
+  __inboxHydrate();
+
+  var VOTE_TOTAL = 320;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
 })();
 </script>
 <div class="flowtoast" id="flowToast" role="status"></div>


### PR DESCRIPTION
MG accepted the re-cut.

**One-click hand-in.** Each pack now saves to [gasyoun/vote-inbox](https://github.com/gasyoun/vote-inbox) and hydrates back, instead of 32 downloaded files to shepherd.

**V17**, from MG's four reports after voting pack 1: submit controls out of the header into a bar stuck at the viewport foot; a full-width progress bar in the sticky header; progress and ETA for **all 320** rather than the current pack; auto-advance landing on a card's top, not its middle.

**Card set proven unchanged** — 320 ids in identical order versus the packs this replaces. The 10 votes already cast survive in the browser (the record is keyed on `sheet_id`); only their exported partial no longer validates, which is the cost MG accepted.

Backed by [SanskritLexicography #1811](https://github.com/gasyoun/SanskritLexicography/pull/1811) and [csl-pyutil v0.21.0](https://github.com/sanskrit-lexicon/csl-pyutil/releases/tag/v0.21.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)