### PR TITLE
vote sheet: commentarystrategies_typed_link_q41 (H3346)

### DIFF
--- a/vote/sheets/commentarystrategies_typed_link_q41.html
+++ b/vote/sheets/commentarystrategies_typed_link_q41.html
@@ -1,0 +1,4050 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="color-scheme" content="dark">
+<meta name="generator" content="csl-pyutil/0.22.0">
+<title>Q4.1 Type-D пилот: root ↔ commentary-citation через linkid (H3346) — 258 items</title>
+<link rel="stylesheet" href="../../../css/commentary.css">
+<style>
+  :root { color-scheme: dark; --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --text:#e6e6e6; --muted:#9aa0aa;
+          --accent:#5b8cff; --ok:#3fb950; --bad:#f85149; --defer:#d29922; --border:#2a2f3a; }
+  * { box-sizing: border-box; }
+  body { background:var(--bg); color:var(--text); font-family:-apple-system,Segoe UI,Roboto,sans-serif;
+         margin:0; padding:0 0 120px 0; }
+  header.top { position:sticky; top:0; z-index:10; background:var(--panel); border-bottom:1px solid var(--border);
+               padding:14px 20px; display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:10px;}
+  header.top h1 { font-size:16px; margin:0; }
+  header.top .sub { color:var(--muted); font-size:12px; max-width:760px; }
+  .tally { display:flex; gap:14px; font-size:13px; }
+  .tally span.count { font-weight:700; }
+  .tally .approve { color:var(--ok); } .tally .reject { color:var(--bad); }
+  .tally .defer { color:var(--defer); } .tally .unvoted { color:var(--muted); }
+  .toolbar { padding:10px 20px; display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  button.dl { background:var(--accent); color:#fff; border:none; padding:8px 14px; border-radius:6px;
+              cursor:pointer; font-size:13px; }
+  button.dl:hover { opacity:.9; }
+  .filterbar { display:flex; gap:6px; flex-wrap:wrap; }
+  .filterbar button { background:var(--panel2); border:1px solid var(--border); color:var(--text);
+                       padding:6px 10px; border-radius:14px; font-size:12px; cursor:pointer; }
+  .filterbar button.active { border-color:var(--accent); color:var(--accent); }
+  main { max-width:980px; margin:0 auto; padding:10px 20px; }
+  .card { background:var(--panel); border:1px solid var(--border); border-radius:10px; padding:16px;
+          margin-bottom:16px; }
+  .card.voted-approve { border-left:4px solid var(--ok); }
+  .card.voted-reject { border-left:4px solid var(--bad); }
+  .card.voted-defer { border-left:4px solid var(--defer); }
+  .card header { display:flex; justify-content:space-between; align-items:baseline; }
+  .card .hw { font-size:18px; font-weight:700; }
+  .badge { font-size:11px; background:var(--panel2); padding:2px 8px; border-radius:10px;
+           margin-left:8px; color:var(--muted); }
+  .question { margin:8px 0 12px; font-size:14px; }
+  .panel { background:var(--panel2); border-radius:8px; padding:10px 12px; font-size:13px; margin-bottom:10px; }
+  .panel h4 { margin:0 0 6px; font-size:11px; text-transform:uppercase; letter-spacing:.04em; color:var(--muted); }
+  .panel pre { white-space:pre-wrap; word-break:break-word; margin:0; font-size:12px; line-height:1.45; }
+  .chip { display:inline-block; background:#263042; border-radius:5px; padding:2px 7px; margin:2px 3px 2px 0; font-size:12px; }
+  .muted { color:var(--muted); font-style:italic; }
+  .controls { display:flex; align-items:center; gap:8px; margin-top:4px; }
+  button.vote { border:1px solid var(--border); background:var(--panel2); color:var(--text);
+                padding:7px 12px; border-radius:6px; cursor:pointer; font-size:13px; }
+  button.vote.approve.active { background:var(--ok); border-color:var(--ok); color:#04240b; }
+  button.vote.reject.active { background:var(--bad); border-color:var(--bad); color:#2a0a08; }
+  button.vote.defer.active { background:var(--defer); border-color:var(--defer); color:#2a1d02; }
+  .vote-state { margin-left:6px; font-size:12px; color:var(--muted); }
+  textarea.note { width:100%; margin-top:10px; min-height:72px; background:#11141a !important; color:#e6e6e6 !important;
+                  -webkit-text-fill-color:#e6e6e6; border:1px solid var(--border); border-radius:6px; padding:8px; font-size:13px;
+                  font-family:inherit; resize:vertical; }
+  textarea.note::placeholder { color:var(--muted); opacity:1; }
+  footer.hint { max-width:980px; margin:20px auto; padding:0 20px; color:var(--muted); font-size:12px; }
+  kbd { background:#263042; border-radius:4px; padding:1px 5px; font-size:11px; }
+
+  .screening-banner { margin: 0 20px 12px; padding: 10px 14px; border-radius: 8px;
+    border: 1px solid var(--accent); background: #152033; font-size: 12px; line-height: 1.45;
+    color: var(--text); max-width: 980px; }
+  .screening-banner code { font-size: 11px; color: var(--accent); }
+  .screening-banner .sc-d { color: var(--defer); font-weight: 700; }
+
+  .idchip { font-family:ui-monospace,Consolas,monospace; font-size:11px; color:var(--muted);
+            background:var(--panel2); border:1px solid var(--border); padding:2px 7px;
+            border-radius:6px; user-select:all; }
+  .card header { gap:10px; }
+  .hw a.hwlink { color:inherit; text-decoration:underline dotted; text-underline-offset:3px; }
+  .hw a.hwlink:hover { color:var(--accent); }
+  mark.hl { background:#453407; color:#ffd75e; padding:0 2px; border-radius:3px; }
+  .savebanner { max-width:980px; margin:10px auto 0; padding:8px 20px; font-size:12.5px; }
+  .savebanner code { background:var(--panel2); border:1px solid var(--border); padding:1px 6px; border-radius:5px; }
+  .ratingrow { display:flex; align-items:center; gap:6px; margin-top:10px; flex-wrap:wrap; }
+  .ratinglabel { font-size:12px; color:var(--muted); margin-right:4px; }
+  button.rate { border:1px solid var(--border); background:var(--panel2); color:var(--text);
+                width:34px; padding:6px 0; border-radius:6px; cursor:pointer; font-size:13px; }
+  button.rate.active { background:var(--accent); border-color:var(--accent); color:#fff; }
+  button.rate.active.below { background:var(--defer); border-color:var(--defer); color:#2a1d02; }
+  .rate-state { font-size:12px; color:var(--muted); margin-left:4px; }
+  .badge-typology { border:1px solid var(--accent); color:var(--text); font-weight:600; }
+  :root { --fs:1.5; }
+  header.top h1 { font-size:calc(16px * var(--fs)) !important; }
+  header.top .sub { font-size:calc(12px * var(--fs)) !important; }
+  .tally, button.dl, button.vote, button.rate, textarea.note, .reject-label-select,
+  #strictReviewerWrap, #strictReviewerWrap input { font-size:calc(13px * var(--fs)) !important; }
+  .filterbar button, .fsctl button, .fsctl .fsval, .chip, .vote-state, .rate-state,
+  .ratinglabel, .rejectlabellabel, footer.hint, div.legend,
+  #strictReviewError { font-size:calc(12px * var(--fs)) !important; }
+  .card .hw { font-size:calc(18px * var(--fs)) !important; }
+  .badge, .panel h4, kbd, .idchip { font-size:calc(11px * var(--fs)) !important; }
+  .question { font-size:calc(14px * var(--fs)) !important; }
+  .panel { font-size:calc(13px * var(--fs)) !important; }
+  .panel pre { font-size:calc(13.5px * var(--fs)) !important; line-height:1.55; }
+  .panel .anatomy { font-size:calc(12.5px * var(--fs)) !important; }
+  .savebanner { font-size:calc(12.5px * var(--fs)) !important; }
+  .fsctl { display:flex; align-items:center; gap:4px; }
+  .fsctl button { background:var(--panel2); border:1px solid var(--border); color:var(--text);
+                  padding:6px 10px; border-radius:14px; cursor:pointer; line-height:1; }
+  .fsctl .fsval { color:var(--muted); min-width:3.4em; text-align:center; }
+  @media (max-width: 640px) {
+    header.top { padding: 10px 14px; flex-direction: column; align-items: stretch; }
+    header.top h1 { font-size: 15px; }
+    .tally { gap: 8px; font-size: 11px; }
+    .toolbar { padding: 8px 14px; }
+    main { padding: 8px 12px; }
+    .card { padding: 12px; }
+    .filterbar { flex-wrap: wrap; }
+    button.dl, button.vote, button.rate, .fsctl button, #saveBtn, #handinBtn, #pauseBtn {
+      min-height: 44px; min-width: 44px; padding: 10px 14px;
+    }
+    .controls { flex-wrap: wrap; }
+    .panel { padding: 8px 10px; }
+    textarea.note { min-height: 60px; }
+  }
+  .tally .time { color:var(--muted); }
+  .dl.handin { background:#243447; }
+  .tally .pausebtn { background:none; border:1px solid var(--border); color:var(--muted);
+                     border-radius:6px; padding:0 6px; margin-left:4px; cursor:pointer;
+                     font-size:inherit; font-family:inherit; line-height:1.6; }
+  .tally .pausebtn.on { color:#ffd479; border-color:#ffd479; }
+  .tally .time.paused { opacity:.45; }
+  .handin-said { color:var(--muted); font-size:12px; margin-left:10px; }
+  .card.kbd-active { outline:2px solid var(--accent); outline-offset:3px; }
+  .tally .tstate { color:var(--muted); font-size:.85em; margin-left:4px; }
+  .tally .tstate.idle { color:var(--defer); }
+  .flowprog { display:inline-flex; align-items:center; gap:8px; color:var(--muted); font-size:12px; }
+  .flowprog .bar { display:inline-block; width:120px; height:6px; border-radius:3px;
+                   background:var(--panel2); border:1px solid var(--border); overflow:hidden; }
+  .flowprog .bar i { display:block; height:6px; background:var(--accent); width:0; }
+  .dl.flowundo { background:#243447; }
+  .flowtoast { position:fixed; left:50%; bottom:24px; transform:translateX(-50%);
+               background:var(--panel2); border:1px solid var(--border); color:var(--text);
+               padding:8px 14px; border-radius:8px; font-size:13px; z-index:50;
+               opacity:0; pointer-events:none; transition:opacity .18s; }
+  .flowtoast.on { opacity:1; }
+  .voteprog { flex:1 0 100%; order:99; background:var(--panel);
+              border-top:1px solid var(--border); margin:6px -20px -14px; padding:8px 20px;
+              display:flex; align-items:center; gap:12px; font-size:12px; color:var(--muted); }
+  .voteprog .bar { flex:1 1 auto; height:8px; border-radius:4px; background:var(--panel2);
+                   border:1px solid var(--border); overflow:hidden; }
+  .voteprog .bar i { display:block; height:100%; width:0; background:var(--ok); transition:width .2s; }
+  .voteprog b { color:var(--text); font-weight:700; }
+  .voteprog .eta { white-space:nowrap; }
+  .votebar { position:sticky; bottom:0; z-index:9; background:var(--panel);
+             border-top:1px solid var(--border); padding:10px 20px; margin-top:24px;
+             display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+  .votebar .spacer { flex:1 1 auto; }
+  .card { scroll-margin-top:96px; }
+  @media (max-width: 640px) { .voteprog { padding:6px 12px; } .votebar { padding:8px 12px; } }
+</style>
+</head>
+<body>
+<header class="top">
+  <div>
+    <h1>Q4.1 Type-D пилот: root ↔ commentary-citation через linkid (H3346) — 258 items</h1>
+    <div class="sub">Generated 26-08-2026 &middot; sheet_id <code>commentarystrategies-sundarakanda-typed-link-q41</code> &middot; 258 строк конкорданса; каждая собрана библиотекой sanskrit-util linkid и прошла linkid_validate_link_record без ошибок. Approve = подтвердить связь в подтверждённый ярус датасета · Reject = снять строку · Defer = нужен другой якорь.</div>
+  </div>
+  <div class="tally" id="tally">
+    <span class="approve">&#9989; <span class="count" id="c-approve">0</span></span>
+    <span class="reject">&#10060; <span class="count" id="c-reject">0</span></span>
+    <span class="defer">&#9208; <span class="count" id="c-defer">0</span></span>
+    <span class="time" title="active time on this sheet (while the tab is visible)">&#9201; <span class="count" id="t-total">0:00</span><span class="tstate" id="t-state"></span></span>
+    <button type="button" class="pausebtn" id="pauseBtn" title="pause the clock — a break is not review time">&#9208;</button>
+    <span class="unvoted">&#9711; <span class="count" id="c-unvoted">258</span></span>
+  </div>
+<div class="voteprog" id="voteProg"><span id="voteProgText"></span><span class="bar"><i id="voteProgBar"></i></span><span class="eta" id="voteProgEta"></span></div>
+</header>
+<aside class="screening-banner" role="status" data-screening="1"><strong>Screening (H1649)</strong> — only human-required cards are below. Off the plate: <span class="sc-a">deterministic 258</span> · <span class="sc-b">dataset lookup 0</span> · <span class="sc-c">agent adjudication 0</span> (total screened 258). Human cards: <span class="sc-d">258</span>. Evidence: <code>data/analysis/typed_link_sundara/dedup_vs_1058.json</code>. Rules: linkid_validate_link_record() 0 ошибок на всех строках, хвосты root: сверены с инвентарём WhitneyRoots mw_roots (704 SLP1-ключа) — вне инвентаря ID не минтуется, дедуп против 1058 посчитан машиной (статус на карточке).</aside>
+<div class="savebanner">&#128229; Your export downloads as <code>commentarystrategies-sundarakanda-typed-link-q41_decisions.json</code> &rarr; save it to <code>CommentaryStrategies\data\analysis\typed_link_sundara\commentarystrategies-sundarakanda-typed-link-q41_decisions.json</code> (the <code>sheet_id</code> inside the file is <code>commentarystrategies-sundarakanda-typed-link-q41</code> — that is how a later session knows which sheet these decisions belong to).</div>
+<div class="toolbar">
+  <button data-submit="1" class="dl" id="downloadBtn">Download decisions.json</button><button data-submit="1" class="dl handin" id="handinBtn" title="stop the clock and export the votes made so far; the rest stay saved in this browser">Hand in what I got</button><span class="handin-said" id="handinSaid"></span><button data-submit="1" class="dl" id="saveBtn" style="display:none;margin-left:8px">Save to folder…</button>
+  <div class="fsctl" title="text size — persists in this browser"><button type="button" id="fsDown" aria-label="smaller text">A&minus;</button><span class="fsval" id="fsVal"></span><button type="button" id="fsUp" aria-label="larger text">A+</button></div>
+  <button data-submit="1" type="button" class="dl flowundo" id="flowUndoBtn" title="undo the last decision (z)">&#8630; Undo</button>
+  <span class="flowprog" id="flowProg"><span class="bar"><i id="flowBar"></i></span><span id="flowProgText"></span><span id="flowEta"></span></span>
+  <div class="filterbar" id="filterbar"><button data-filter="all" class="active">all</button><button data-filter="root-overlap">⚠ дубликат-кандидат</button><button data-filter="verse-overlap">➕ стих покрыт, корень нов</button><button data-filter="unique-vs-1058">✅ уникально</button><button data-filter="unvoted">unvoted only</button></div>
+</div>
+<main class="container">
+<div id="cards">
+
+  <section class="card" data-id="root:kfS|commentary:sundara-lexical:V.1.1" data-filt="verse-overlap">
+    <header><div class="hw">√kṛś @ V.1.1 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма śatrukārśana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kfS|commentary:sundara-lexical:V.1.1</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kfS</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kṛś — цитируется в аппарате на <code>commentary:sundara-lexical:V.1.1</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Иссушитель врагов (śatru-kārśana) — букв.: «иссушающий врагов»; имя деятеля от каузатива корня kṛś- «быть тощим»: kṛśayati «изнуряет, делает тощим». Эпитет рисует Раму истощителем противников — сильнее нейтральных «победитель» (vijayī) или «убийца» (hantṛ).</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_1_1</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:DA|commentary:sundara-lexical:V.1.5" data-filt="verse-overlap">
+    <header><div class="hw">√dhā @ V.1.5 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма dhātu</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:DA|commentary:sundara-lexical:V.1.5</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:DA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhā — цитируется в аппарате на <code>commentary:sundara-lexical:V.1.5</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Рудные жилы (dhātu) — букв.: «то, что несёт, поддерживает», от корня dhā- «класть, поддерживать»; в описании горы — слои породы, рудные жилы. Слово многозначно: минерал горы, первоэлемент тела, грамматический корень. Гора сияет «чистыми, природой созданными» жилами — опорами, на которых она держится.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_1_5</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:plu|commentary:sundara-lexical:V.1.9" data-filt="verse-overlap">
+    <header><div class="hw">√plu @ V.1.9 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма plavaṃgama</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:plu|commentary:sundara-lexical:V.1.9</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:plu</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √plu — цитируется в аппарате на <code>commentary:sundara-lexical:V.1.9</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Прыгун (plavaṃ-gama) — букв.: «движущийся прыжком», от корней plu- «прыгать, плыть» и gam- «идти»; обычное в эпосе обозначение обезьяны по способу передвижения — рядом с более общим plavaga «прыгун». Слово описывает модус движения, а не облик.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_1_9</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:cal|commentary:sundara-lexical:V.1.12" data-filt="verse-overlap">
+    <header><div class="hw">√cal @ V.1.12 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма acala</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:cal|commentary:sundara-lexical:V.1.12</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:cal</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √cal — цитируется в аппарате на <code>commentary:sundara-lexical:V.1.12</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Гора (a-cala) — букв.: «неподвижная», от корня cal- «двигаться»: гора как вечно-недвижное. В стихе намеренный оксюморон: «та неподвижная задвигалась» (cacāla acalaḥ) — игра однокоренных слов, обыгрывающая имя и природу горы.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_1_12</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:dyut|commentary:sundara-lexical:V.1.53" data-filt="verse-overlap">
+    <header><div class="hw">√dyut @ V.1.53 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма khādyota</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:dyut|commentary:sundara-lexical:V.1.53</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:dyut</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dyut — цитируется в аппарате на <code>commentary:sundara-lexical:V.1.53</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Светляк (khādyota) — букв.: «небесное сияние»: сложение kha «небо, пространство» и dyota «сияние» (от корня dyut- «сиять», с удлинением гласного на стыке). Хануман, осыпанный цветами, уподоблен горе, покрытой светляками ночью; сравнение, разрабатываемое и в учёной поэзии (кавье).</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_1_53</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:dyut|commentary:sundara-lexical:V.1.58" data-filt="verse-overlap">
+    <header><div class="hw">√dyut @ V.1.58 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма vidyut</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:dyut|commentary:sundara-lexical:V.1.58</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:dyut</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dyut — цитируется в аппарате на <code>commentary:sundara-lexical:V.1.58</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Молния (vidyut) — букв.: «сверкающая», от корня dyut- «блистать» с приставкой vi-; слово женского рода — в ведийской традиции молния персонифицирована как богиня. Облик Ханумана «сияет как молния»: выбрано именно оно, а не оружейное vajra — блеск природный, не кованый.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_1_58</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:ji|commentary:sundara-lexical:V.6.21" data-filt="verse-overlap">
+    <header><div class="hw">√ji @ V.6.21 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма indrajit</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:ji|commentary:sundara-lexical:V.6.21</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:ji</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ji — цитируется в аппарате на <code>commentary:sundara-lexical:V.6.21</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Индраджит (indrajit, m.) — «победивший Индру»: indra + √ji- («побеждать»). MW: indrajit &#x27;conquering Indra; N. of a son of Rāvaṇa&#x27;. Настоящее имя — Meghanāda «гром облаков»; эпитет Indrajit получен за пленение царя богов Индры в битве (MBh, R. I). Это ключевая фигура «Сундараканды»: именно Индраджит позднее поймает Ханумана нагапашей (V.46). Первое появление в гл. 6 — как сосед Кумбхакарны и Вибхиш</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_6_21</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:lakz|commentary:sundara-lexical:V.7.14" data-filt="verse-overlap">
+    <header><div class="hw">√lakṣ @ V.7.14 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма lakṣmī</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:lakz|commentary:sundara-lexical:V.7.14</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:lakz</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √lakṣ — цитируется в аппарате на <code>commentary:sundara-lexical:V.7.14</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Лакшми (lakṣmī, f.) — богиня счастья и процветания; этимология: √lakṣ- («замечать, распознавать», MW) + суфф. -mī, или родственно lakṣaṇa «знак, примета». MW: lakṣmī &#x27;good luck, fortune, prosperity, beauty; the goddess of fortune and beauty&#x27;. Иконографически зафиксирована в V.7.14 в точном каноническом образе: padminī «среди лотосов» + padmahastā «с лотосом в руке» — стандартная Гаджа-Лакшми (abhi</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_7_14</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:siD|commentary:sundara-lexical:V.9.30" data-filt="verse-overlap">
+    <header><div class="hw">√sidh @ V.9.30 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма siddhi</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:siD|commentary:sundara-lexical:V.9.30</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:siD</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sidh — цитируется в аппарате на <code>commentary:sundara-lexical:V.9.30</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Сиддхи (siddhi, f.) — «осуществление, совершенство, мистическое достижение»; от √sidh- («достигать, осуществляться», Whitney). MW: siddhi &#x27;accomplishment, fulfilment, success; the acquisition of supernatural powers by magical means&#x27;. В V.9.30 Хануман думает: «это — svarga! это — devaloka! siddhir veyaṃ parā — или это высшая siddhi [гандхарвов]?» Здесь siddhi в значении «иллюзия, магическое создани</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_9_30</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:su|commentary:sundara-lexical:V.9.56" data-filt="verse-overlap">
+    <header><div class="hw">√su @ V.9.56 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма śarkarāsava</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:su|commentary:sundara-lexical:V.9.56</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:su</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √su — цитируется в аппарате на <code>commentary:sundara-lexical:V.9.56</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Шаркарасава (śarkarā-āsava, m.) — «сахарное вино, сладкое хмельное»: śarkarā «сахар, гравий» (от √śarkar-, ср. перс. shakar, англ. sugar) + āsava «перегнанный/настоянный напиток» (от √su- «выжимать, гнать»). MW: śarkarā &#x27;gravel, grit; sugar&#x27;; āsava &#x27;a spirituous liquor, distilled from sugar, molasses or the flowers of the Bassia&#x27;. Śarkarāsava — классифицированный напиток в Аюрведе (Charaka-saṃhitā</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_9_56</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:gA|commentary:sundara-lexical:V.9.68" data-filt="verse-overlap">
+    <header><div class="hw">√gā @ V.9.68 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма gandharva</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:gA|commentary:sundara-lexical:V.9.68</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:gA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √gā — цитируется в аппарате на <code>commentary:sundara-lexical:V.9.68</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Гандхарва (gandharva, m.) — полубожественные существа, небесные певцы и музыканты. MW: gandharva &#x27;a Gandharva or heavenly musician (the Gandharvas are said to have rule over horses and to be fond of women; they are the husbands of the Apsarases; their king is Viśvāvasu)&#x27;. Этимология неясна: народная — gandha «аромат» + √gā- «петь» = «поющий ароматный»; более вероятно заимствование из авестийского </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_9_68</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:f|commentary:sundara-lexical:V.9.73" data-filt="verse-overlap">
+    <header><div class="hw">√ṛ @ V.9.73 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма anāryakarman</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:f|commentary:sundara-lexical:V.9.73</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:f</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.9.73</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Анарьякарман (anārya-karman, n.) — «деяние, недостойное арья», anārya + karman. MW: anārya &#x27;not honourable, ignoble, base&#x27;; ārya &#x27;respectable, noble; a man of the first three castes&#x27;. Термин ārya (√ṛ- «двигаться к цели», ср. авест. airya, ст.-перс. ariya) в эпосе — не этническое, а дхармическое: ārya = соответствующий дхарме, «благородный по поступкам». AnAryakarman — нарушение базового дхармическ</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_9_73</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:aj|commentary:sundara-lexical:V.10.5" data-filt="verse-overlap">
+    <header><div class="hw">√aj @ V.10.5 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма vālavyajana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:aj|commentary:sundara-lexical:V.10.5</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:aj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √aj — цитируется в аппарате на <code>commentary:sundara-lexical:V.10.5</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Валавьяджана (vāla-vyajana, n.) — «опахало из хвостового волоса [яка]», тат-пуруша: vāla «хвостовой волос, щетина» (MW: &#x27;hair of the tail&#x27;) + vyajana «опахало, веер» (vi+√aj-, «гнать»). Конкретный вид придворного опахала: из хвоста яка (Bos grunniens), выкрашенного в белый. В индийской иконографии vālavyajana — специфический атрибут прислуги при царственных особах; как два flanking vacīdhara — слу</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_10_5</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:sru|commentary:sundara-lexical:V.10.14" data-filt="verse-overlap">
+    <header><div class="hw">√sru @ V.10.14 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма prasravaṇa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:sru|commentary:sundara-lexical:V.10.14</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:sru</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sru — цитируется в аппарате на <code>commentary:sundara-lexical:V.10.14</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Прасраваная (prasravaṇa, m./n.) — «горный поток, источник; гора Прасрана» (геоним). MW: prasravaṇa &#x27;flowing forth, a stream, spring; N. of a mountain&#x27;. В сравнении с Раваной, спящим на ложе: гора, на которой лежит слон. Pra-sravaṇa от pra+√sru- («течь вперёд»): «изливающийся» — гора, из которой бьют ключи, типичный пейзажный образ эпоса. В Рамаяне Prasravaṇa — конкретная гора в Кишкиндхе, где Рама</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_10_14</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:yaj|commentary:sundara-lexical:V.10.20" data-filt="verse-overlap">
+    <header><div class="hw">√yaj @ V.10.20 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма yakṣa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:yaj|commentary:sundara-lexical:V.10.20</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:yaj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √yaj — цитируется в аппарате на <code>commentary:sundara-lexical:V.10.20</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Якша (yakṣa, m.) — «якша», класс сверхъестественных существ. MW: yakṣa &#x27;a kind of supernatural being (attendant esp. on Kubera); a ghost, spirit&#x27;. Этимология спорна: √yaj- («почитать») → yakṣa как «почитаемый» или же √yakṣ- (редкий глагол «блистать, спешить»). В эпосе якши противопоставлены ракшасам: якши — существа преимущественно благожелательные, связанные с природными богатствами и Куберой; ра</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_10_20</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:as|commentary:sundara-lexical:V.12.3" data-filt="verse-overlap">
+    <header><div class="hw">√as @ V.12.3 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма satī</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:as|commentary:sundara-lexical:V.12.3</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:as</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √as — цитируется в аппарате на <code>commentary:sundara-lexical:V.12.3</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Сати (satī, f.) — «добродетельная жена, верная супруга»; p.p.p. от √as- («быть») в специализированном значении: «та, которая есть [в истинном смысле]», то есть «истинная, подлинная». MW: satī &#x27;a good and faithful wife&#x27;. Термин satī предшествует историческому ритуалу самосожжения (satī-dāha, известному с ок. IX в.), хотя в эпосе уже несёт семантику абсолютной супружеской верности. В данном стихе Дж</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_12_3</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vad|commentary:sundara-lexical:V.12.10" data-filt="verse-overlap">
+    <header><div class="hw">√vad @ V.12.10 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма anirveda</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vad|commentary:sundara-lexical:V.12.10</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vad</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vad — цитируется в аппарате на <code>commentary:sundara-lexical:V.12.10</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Анирведа (anirveda, m.) — «неунывание, несдавание, стойкость духа», a-nirveda: отрицательная приставка a- + nirveda («уныние, разочарование», от nir+√vid- или nir+√vad-). MW: nirveda &#x27;indifference, aversion; despondency&#x27;. Данный стих формулирует максиму: anirvedaḥ śriyo mūlam — «стойкость = корень процветания»; anirvedaḥ paraṃ sukham — «стойкость = высшее счастье». Это сентенция (sūkta) гномическо</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_12_10</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vid|commentary:sundara-lexical:V.12.10" data-filt="verse-overlap">
+    <header><div class="hw">√vid @ V.12.10 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма anirveda</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vid|commentary:sundara-lexical:V.12.10</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vid</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vid — цитируется в аппарате на <code>commentary:sundara-lexical:V.12.10</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Анирведа (anirveda, m.) — «неунывание, несдавание, стойкость духа», a-nirveda: отрицательная приставка a- + nirveda («уныние, разочарование», от nir+√vid- или nir+√vad-). MW: nirveda &#x27;indifference, aversion; despondency&#x27;. Данный стих формулирует максиму: anirvedaḥ śriyo mūlam — «стойкость = корень процветания»; anirvedaḥ paraṃ sukham — «стойкость = высшее счастье». Это сентенция (sūkta) гномическо</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_12_10</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:ci|commentary:sundara-lexical:V.12.15" data-filt="verse-overlap">
+    <header><div class="hw">√ci @ V.12.15 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма caityagṛha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:ci|commentary:sundara-lexical:V.12.15</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:ci</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ci — цитируется в аппарате на <code>commentary:sundara-lexical:V.12.15</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Чайтьягриха (caitya-gṛha, n.) — «дом-чайтья, святилище», тат-пуруша: caitya (MW: &#x27;a funeral mound, a sacred tree, an alms-house; a place of worship&#x27;) + gṛha «дом». Caitya от √ci- («складывать, собирать»): изначально надгробный курган; затем — любое сакральное сооружение (буддийские чайтьи — ступы). В эпосе caityagṛha = небольшое домашнее или придорожное святилище с деревом. Хануман осматривает cai</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_12_15</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:siD|commentary:sundara-lexical:V.13.8" data-filt="verse-overlap">
+    <header><div class="hw">√sidh @ V.13.8 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма siddha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:siD|commentary:sundara-lexical:V.13.8</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:siD</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sidh — цитируется в аппарате на <code>commentary:sundara-lexical:V.13.8</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Сиддха (siddha, m.) — «совершенный / достигший [освобождения]»; p.p.p. от √sidh- («достигать, совершать»). MW: siddha &#x27;accomplished, fulfilled; a semi-divine being of great purity and perfection&#x27;. В космологии эпоса сиддхи населяют antara-kha («межпространство»), между землёй и небом — именно «путь, по которому ходят siddhi» (siddha-niṣevite). Это существа, уже вышедшие из круга перерождений через</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_13_8</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:sTA|commentary:sundara-lexical:V.13.40" data-filt="verse-overlap">
+    <header><div class="hw">√sthā @ V.13.40 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма vānaprastha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:sTA|commentary:sundara-lexical:V.13.40</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:sTA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sthā — цитируется в аппарате на <code>commentary:sundara-lexical:V.13.40</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Ванапрастха (vāna-prastha, m.) — «удалившийся в лес», третья стадия (āśrama) жизненного пути: vana «лес» + prastha «отправляющийся» (pra+√sthā-). MW: vānaprastha &#x27;a forest-dweller; the third of the four stages of the religious life of a Brāhmaṇa&#x27;. Четыре āśrama: brahmacarya (ученик) → gṛhastha (домохозяин) → vānaprastha (лесной отшельник) → saṃnyāsa (странствующий аскет). Хануман формулирует своё </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_13_40</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:hfz|commentary:sundara-lexical:V.14.2" data-filt="verse-overlap">
+    <header><div class="hw">√hṛṣ @ V.14.2 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма saṃhṛṣṭasarvāṅga</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:hfz|commentary:sundara-lexical:V.14.2</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:hfz</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √hṛṣ — цитируется в аппарате на <code>commentary:sundara-lexical:V.14.2</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Самхриштасарванга (saṃhṛṣṭa-sarva-aṅga, adj.) — бахуврихи: saṃhṛṣṭa «охваченный восторгом» (sam+√hṛṣ-, «щетиниться, трепетать», MW: hṛṣ &#x27;to be excited, thrilled&#x27;) + sarva «весь» + aṅga «член тела». Буквально: «у которого все члены тела встали дыбом». В санскритском эпосе hṛṣita/saṃhṛṣṭa означает физический аффективный отклик — «гусиная кожа» от радостного возбуждения. В подстрочнике: «все тело охв</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_14_2</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Suc|commentary:sundara-lexical:V.14.3" data-filt="verse-overlap">
+    <header><div class="hw">√śuc @ V.14.3 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма aśoka</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Suc|commentary:sundara-lexical:V.14.3</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Suc</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √śuc — цитируется в аппарате на <code>commentary:sundara-lexical:V.14.3</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Ашока (aśoka, m. — Saraca asoca, сем. Fabaceae) — «без-скорби» (a- + śoka, «скорбь», √śuc-). MW: aśoka &#x27;the tree Jonesia Aśoka Roxb., giving no grief&#x27;. Народная этимология эксплицитно мотивирует имя дерева: оно «не даёт śoka» — или защищает от него. Именно поэтому роща называется Aśokavanikā, а Сита укрыта под ашокой: дерево «без скорби» обрамляет наибольшую скорбь поэмы. Парономазия śoka / a-śoka</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_14_3</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:DA|commentary:sundara-lexical:V.14.49" data-filt="verse-overlap">
+    <header><div class="hw">√dhā @ V.14.49 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма saṃdhyā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:DA|commentary:sundara-lexical:V.14.49</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:DA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhā — цитируется в аппарате на <code>commentary:sundara-lexical:V.14.49</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Самдхья (saṃdhyā, f.) — «сумерки; пограничный ритуал» (sam+√dhā-, «соединять», Whitney #163; saṃdhyā = «со-единение [дня и ночи]»). MW: saṃdhyā &#x27;junction, morning/evening twilight; the religious ceremonies performed at the junction of day and night&#x27;. Saṃdhyā — не просто «вечер»: это священный момент перехода, требующий обязательного ритуала (saṃdhyāvandana — медитации и возлияния воде), который в </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_14_49</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:ci|commentary:sundara-lexical:V.15.16" data-filt="verse-overlap">
+    <header><div class="hw">√ci @ V.15.16 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма caityaprāsāda</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:ci|commentary:sundara-lexical:V.15.16</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:ci</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ci — цитируется в аппарате на <code>commentary:sundara-lexical:V.15.16</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Чаитьяпрасада (caitya-prāsāda, m.) — тат-пуруша: caitya «священный объект, курган, алтарь под открытым небом» (от cita «сложенный из кирпичей», p.p. от √ci-; MW: caitya &#x27;a funeral mound, a sacred fig-tree, a Buddhist caitya-hall&#x27;) + prāsāda «дворец» (pra+√sad-). Этот термин специфически описывает строение, совмещающее ступу-мемориал и дворцовую архитектуру. В «Рамаяне» — архитектурная реалия Ланки</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_15_16</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:sad|commentary:sundara-lexical:V.15.16" data-filt="verse-overlap">
+    <header><div class="hw">√sad @ V.15.16 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма caityaprāsāda</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:sad|commentary:sundara-lexical:V.15.16</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:sad</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sad — цитируется в аппарате на <code>commentary:sundara-lexical:V.15.16</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Чаитьяпрасада (caitya-prāsāda, m.) — тат-пуруша: caitya «священный объект, курган, алтарь под открытым небом» (от cita «сложенный из кирпичей», p.p. от √ci-; MW: caitya &#x27;a funeral mound, a sacred fig-tree, a Buddhist caitya-hall&#x27;) + prāsāda «дворец» (pra+√sad-). Этот термин специфически описывает строение, совмещающее ступу-мемориал и дворцовую архитектуру. В «Рамаяне» — архитектурная реалия Ланки</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_15_16</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:ruh|commentary:sundara-lexical:V.15.22" data-filt="verse-overlap">
+    <header><div class="hw">√ruh @ V.15.22 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма rohiṇī</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:ruh|commentary:sundara-lexical:V.15.22</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:ruh</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ruh — цитируется в аппарате на <code>commentary:sundara-lexical:V.15.22</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Рохини (Rohiṇī, f.) — «красная» (√ruh- «подниматься, краснеть»): 1) астероним — 4-я лунная стоянка (nakṣatra), отождествляемая с Альдебараном (α Tauri), любимейшее созвездие Луны; 2) имя собственное — возлюбленная Луны. MW: Rohiṇī &#x27;the 4th lunar mansion; the favourite wife of the Moon&#x27;. В 15.22 Сита сравнивается с Рохини, угнетаемой Марсом (Aṅgāraka). Астрологический контекст: Марс считался неблаг</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_15_22</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Bf|commentary:sundara-lexical:V.17.21" data-filt="verse-overlap">
+    <header><div class="hw">√bhṛ @ V.17.21 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма bhartṛvātsalya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Bf|commentary:sundara-lexical:V.17.21</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Bf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.17.21</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Бхартривасалья (bhartṛ-vātsalya, n.) — «нежная любовь к мужу»; bhartṛ «господин, муж» (от √bhṛ-, «нести, содержать», Whitney #588) + vātsalya «нежная привязанность» (от vatsa «телёнок» → «любимый ребёнок»). MW: vātsalya &#x27;fondness for offspring or young, tender love&#x27;. Словосочетание строится на парадоксе: Сита лишена внешних украшений (bhūṣaṇa), но «украшена» (bhūṣita) невидимым — своей привязаннос</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_17_21, comment_17_21</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vad|commentary:sundara-lexical:V.18.3" data-filt="verse-overlap">
+    <header><div class="hw">√vad @ V.18.3 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма maṅgalavāditra</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vad|commentary:sundara-lexical:V.18.3</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vad</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vad — цитируется в аппарате на <code>commentary:sundara-lexical:V.18.3</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Мангалавадитра (maṅgala-vāditra, n.) — «благоприятные инструменты, игра на которых приносит счастье»; maṅgala «благо, счастье» + vāditra «музыкальный инструмент» (√vad-, «звучать», Whitney #766). Утреннее пробуждение царя (prabhātasevā) посредством инструментального ансамбля — устойчивый ритуал царской жизни (rājadharma); описан в Arthaśāstra 2.20. Раван просыпается как царь, по царскому ритуалу —</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_18_3</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vyaD|commentary:sundara-lexical:V.18.23" data-filt="verse-overlap">
+    <header><div class="hw">√vyadh @ V.18.23 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма kandarpāpaviddhaśarāsana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vyaD|commentary:sundara-lexical:V.18.23</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vyaD</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vyadh — цитируется в аппарате на <code>commentary:sundara-lexical:V.18.23</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Кандарпапавиддхашарасана (kandarp-apaviddha-śarāsana, компаунд) — «Кама, отбросивший свой лук» (kandarpa = Кама + apaviddha «отброшенный» p.p.p. от ava+√vyadh- «метать» + śarāsana «лук»). Иконографически Кама изображается с луком из стеблей сахарного тростника и стрелами-цветами (pañcabāṇa). Образ «Камы без лука» значим: он сам воплощает желание настолько, что его атрибуты не нужны — он сам и есть</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_18_23</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kf|commentary:sundara-lexical:V.19.10" data-filt="verse-overlap">
+    <header><div class="hw">√kṛ @ V.19.10 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма punaḥsaṃskāra</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kf|commentary:sundara-lexical:V.19.10</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.19.10</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Пунахсамскара (punaḥ-saṃskāra, m.) — «повторный / второй ритуал очищения». Saṃskāra (sam+√kṛ «совершать») — цикл ритуалов перехода (garbhādhāna, nāmakaraṇa, upanayana, vivāha и т.д.), MW: saṃskāra &#x27;making perfect; refinement; a rite, ceremony&#x27;. Смысл стиха 19.10 намеренно тёмен: Сита родилась в добродетельной семье (vṛttaśīla kula), но «получила повторный ритуал» (punaḥsaṃskāram āpannā) — словно р</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_19_10</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Df|commentary:sundara-lexical:V.20.5" data-filt="verse-overlap">
+    <header><div class="hw">√dhṛ @ V.20.5 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма svadharma</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Df|commentary:sundara-lexical:V.20.5</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Df</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.20.5</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Свадхарма (sva-dharma, m.) — «своя дхарма, собственный долг / природа»: sva «свой» + dharma «закон, долг, природа» (√dhṛ-, «держать»). Слово техническое: svadharma означает не просто «обычай», но специфическую обязанность, вытекающую из природы существа или его варны / класса. MW: svadharma &#x27;one&#x27;s own duty&#x27;. Равана аргументирует, что похищение чужих жён — буквально «своя дхарма ракшасов», т.е. кон</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_20_5</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:SI|commentary:sundara-lexical:V.20.26" data-filt="verse-overlap">
+    <header><div class="hw">√śī @ V.20.26 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма sthaṇḍilaśāyin</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:SI|commentary:sundara-lexical:V.20.26</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:SI</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √śī — цитируется в аппарате на <code>commentary:sundara-lexical:V.20.26</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Стхандилашайин (sthaṇḍila-śāyin, adj.) — «спящий/лежащий на голой земле»: sthaṇḍila «ровный голый клочок земли» (ритуальная площадка, специально выровненная и очищенная) + śāyin (√śī-, «лежать»). MW: sthaṇḍila &#x27;a piece of bare ground; the ground prepared for a sacrifice&#x27;. Равана использует sthaṇḍilaśāyin как уничижение: Рама ведёт жизнь аскета, спящего на «земле для жертвоприношений», т.е. лишён н</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_20_26</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vf|commentary:sundara-lexical:V.21.27" data-filt="verse-overlap">
+    <header><div class="hw">√vṛ @ V.21.27 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма vara</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vf|commentary:sundara-lexical:V.21.27</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.21.27</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Вара (vara, m./adj.) — «дар, милость богов; лучший, превосходнейший», от √vṛ- («избирать, желать», Whitney #690). MW: vara &#x27;choosing; a boon, gift, blessing; best, excellent&#x27;. Семантика vara охватывает одновременно «выбор» и «полученный дар»: получить vara от бога = быть «избранным». В эпосе vara Раваны — бессмертие, полученное от Брахмы в обмен на тапас. Трагическая ирония: vara = «лучший выбор»,</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_21_27</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:sf|commentary:sundara-lexical:V.22.3" data-filt="verse-overlap">
+    <header><div class="hw">√sṛ @ V.22.3 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма susārathi</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:sf|commentary:sundara-lexical:V.22.3</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:sf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.22.3</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Сусаратхи (su-sārathi, m.) — «хороший возница»: su- «хорошо» + sārathi (√sṛ- «двигаться» или sa-+ratha «при колеснице») — «возница, правящий колесницей». MW: sārathi &#x27;a charioteer&#x27;. Сравнение kāma с вожжами, а sārathi — с мудрецом — типичная упанишадическая метафора (Катха-упанишада 3.3–4: тело = колесница, манас = вожжи, буддхи = возница). Равана здесь переключает её в bhauma-регистр: речь идёт н</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_22_3</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vft|commentary:sundara-lexical:V.22.12" data-filt="verse-overlap">
+    <header><div class="hw">√vṛt @ V.22.12 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма vṛttaśauṭīrya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vft|commentary:sundara-lexical:V.22.12</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vft</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vṛt — цитируется в аппарате на <code>commentary:sundara-lexical:V.22.12</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Вриттташаутирья (vṛtta-śauṭīrya, n.) — «гордость добродетелью / доблестью»: vṛtta «поведение, добродетель, прожитая жизнь» (p.p.p. от √vṛt-, «вращаться, действовать») + śauṭīrya «гордость, высокомерие в смысле достоинства» (MW: śauṭīrya &#x27;bravery, manliness; pride&#x27;). Составное — оксюморон: garvita (гордость) традиционно отрицательное, но vṛtta-гордость = «гордость, вытекающая из добродетели». Подст</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_22_12</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:sic|commentary:sundara-lexical:V.23.11" data-filt="verse-overlap">
+    <header><div class="hw">√sic @ V.23.11 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма vīryotsikta</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:sic|commentary:sundara-lexical:V.23.11</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:sic</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sic — цитируется в аппарате на <code>commentary:sundara-lexical:V.23.11</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Вирьотсикта (vīrya-utsikta, adj.) — «пьяный от мужества, опьянённый доблестью»: vīrya «мужество, доблесть, мощь» (от vīra «герой») + utsikta (ud+√sic-, «лить через край; быть переполненным») = «переполненный, гордый до предела». MW: utsikta &#x27;overflowing; proud, arrogant&#x27;. Буквально: тот, в ком vīrya бьёт через край. Это не комплимент: utsikta несёт коннотацию «слишком много», гибриса. Ракшаси преп</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_23_11</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:aS|commentary:sundara-lexical:V.24.47" data-filt="verse-overlap">
+    <header><div class="hw">√aś @ V.24.47 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма piśitāśana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:aS|commentary:sundara-lexical:V.24.47</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:aS</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √aś — цитируется в аппарате на <code>commentary:sundara-lexical:V.24.47</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Пишиташана (piśitāśana, m./f.) — «питающийся мясом (piśita)», эпитет ракшасов. piśita — «отрезанное, разделанное мясо» (от √piś-, «резать, украшать»); āśana — «едящий» (√aś-, «есть», + суфф. -ana). MW: piśitāśana &#x27;a flesh-eater; a rākṣasa&#x27;. Характерно, что в стихе 34 перечислены именно «пожиратели плоти»: māṃsa («мясо», в том числе в стихах 40–47) последовательно уточняется до «человеческого мяса»</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_24_47</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:piS|commentary:sundara-lexical:V.24.47" data-filt="verse-overlap">
+    <header><div class="hw">√piś @ V.24.47 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма piśitāśana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:piS|commentary:sundara-lexical:V.24.47</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:piS</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √piś — цитируется в аппарате на <code>commentary:sundara-lexical:V.24.47</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Пишиташана (piśitāśana, m./f.) — «питающийся мясом (piśita)», эпитет ракшасов. piśita — «отрезанное, разделанное мясо» (от √piś-, «резать, украшать»); āśana — «едящий» (√aś-, «есть», + суфф. -ana). MW: piśitāśana &#x27;a flesh-eater; a rākṣasa&#x27;. Характерно, что в стихе 34 перечислены именно «пожиратели плоти»: māṃsa («мясо», в том числе в стихах 40–47) последовательно уточняется до «человеческого мяса»</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_24_47</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:gad|commentary:sundara-lexical:V.25.2" data-filt="verse-overlap">
+    <header><div class="hw">√gad @ V.25.2 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма bāṣpagadgada</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:gad|commentary:sundara-lexical:V.25.2</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:gad</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √gad — цитируется в аппарате на <code>commentary:sundara-lexical:V.25.2</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Башпагадгада (bāṣpa-gadgada, adj.) — «(речь,) прерывающаяся (gadgada) от слёз (bāṣpa)». gadgada — звукоподражательное слово (√gad- «говорить неясно» + редупликация), MW: gadgada &#x27;stammering, stuttering; indistinct or convulsive utterance (as sobbing)&#x27;. bāṣpa «слеза» восходит к корню √bāṣp- или связывается народной этимологией с «паром, испарением» (ср. bahiṣpavamāna). Сложное слово gadgada-gir/gad</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_25_2</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:ji|commentary:sundara-lexical:V.26.47" data-filt="verse-overlap">
+    <header><div class="hw">√ji @ V.26.47 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма jitātman</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:ji|commentary:sundara-lexical:V.26.47</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:ji</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ji — цитируется в аппарате на <code>commentary:sundara-lexical:V.26.47</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Джитатман (jitātman, adj.) — «победивший (jita, p.p.p. от √ji-) себя (ātman)». MW: jitātman &#x27;one who has subdued his soul or passions&#x27;. Технический термин йоги и аскетики: тот, кто преодолел не внешних врагов, а внутренние силы (desire, aversion, ego). Контекст: Сита завершает плач восхвалением муни, у которых нет «приятного и неприятного» (priyāpriye). jitātman — высшая стадия этого пути: не прос</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_26_47</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:lok|commentary:sundara-lexical:V.28.6" data-filt="verse-overlap">
+    <header><div class="hw">√lok @ V.28.6 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма lokanātha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:lok|commentary:sundara-lexical:V.28.6</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:lok</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √lok — цитируется в аппарате на <code>commentary:sundara-lexical:V.28.6</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Локаната (loka-nātha, m., тат-пуруша) — «владыка мира(ов)»: loka «мир, люди, область» (этимология спорна; MW связывает с √lok- «видеть» или с √ruc- «сиять»; Grassmann: IE *leuk- «свет») + nātha «защитник, господин» (√nāth-, MW: &#x27;to seek aid; lord, refuge&#x27;). MW: lokanātha &#x27;lord of the world; epithet of Vishnu, Brahmā, Śiva, a Buddhist deity&#x27;. Эпитет демонстративно многозначен: он прилагается к Вишн</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_28_6</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:ruc|commentary:sundara-lexical:V.28.6" data-filt="verse-overlap">
+    <header><div class="hw">√ruc @ V.28.6 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма lokanātha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:ruc|commentary:sundara-lexical:V.28.6</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:ruc</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ruc — цитируется в аппарате на <code>commentary:sundara-lexical:V.28.6</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Локаната (loka-nātha, m., тат-пуруша) — «владыка мира(ов)»: loka «мир, люди, область» (этимология спорна; MW связывает с √lok- «видеть» или с √ruc- «сиять»; Grassmann: IE *leuk- «свет») + nātha «защитник, господин» (√nāth-, MW: &#x27;to seek aid; lord, refuge&#x27;). MW: lokanātha &#x27;lord of the world; epithet of Vishnu, Brahmā, Śiva, a Buddhist deity&#x27;. Эпитет демонстративно многозначен: он прилагается к Вишн</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_28_6</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:SAs|commentary:sundara-lexical:V.32.9" data-filt="verse-overlap">
+    <header><div class="hw">√śās @ V.32.9 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма śāstragaṇa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:SAs|commentary:sundara-lexical:V.32.9</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:SAs</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √śās — цитируется в аппарате на <code>commentary:sundara-lexical:V.32.9</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Шастрагана (śāstra-gaṇa, m.) — «множество предписаний/традиций»: śāstra (от √śās- «наставлять, повелевать, предписывать») «наука, авторитетный текст» + gaṇa «группа, множество». В 32.9 svapno mayāyaṃ vikṛto dṛṣṭaḥ / śākhāmṛgaḥ śāstragaṇair niṣiddhaḥ — Сита ссылается на авторитет традиционных текстов, запрещающих видеть обезьян во сне. В онирокритике (svapnaśāstra) и пуранических списках сновидений</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_32_9</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:gA|commentary:sundara-lexical:V.34.6" data-filt="verse-overlap">
+    <header><div class="hw">√gā @ V.34.6 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма laukikī gāthā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:gA|commentary:sundara-lexical:V.34.6</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:gA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √gā — цитируется в аппарате на <code>commentary:sundara-lexical:V.34.6</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Лаукики гатха (laukikī gāthā) — «народная поговорка/песня», букв. «мирская (laukika) стихотворная сентенция (gāthā)». Gāthā (√gā- «петь») — архаичный термин для поучительного стиха вневедийского происхождения; MW: gāthā «a verse or stanza not of Vedic origin». Laukika противопоставляется śāstrīya (шастрам) и vaidika (ведам): это знание, закреплённое в народном сознании. Сита цитирует поговорку «к </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_34_6</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:guh|commentary:sundara-lexical:V.35.15" data-filt="verse-overlap">
+    <header><div class="hw">√guh @ V.35.15 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма gūḍhajatru</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:guh|commentary:sundara-lexical:V.35.15</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:guh</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √guh — цитируется в аппарате на <code>commentary:sundara-lexical:V.35.15</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Гудхаджатру (gūḍha-jatru, adj.) — «с утопленными ключицами», бахуврихи: gūḍha (p.p.p. от √guh- «прятать») + jatru «ключица». MW: gūḍhajatru «one whose collar-bones are concealed by flesh». Выпуклые мышцы груди и плеч, скрывающие ключицы — признак физической мощи и знак mahāpuruṣa-lakṣaṇa (знаков великого человека). В буддийской традиции эти же «32 знака» описываются для Будды; в эпосе они применяю</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_35_15</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Sap|commentary:sundara-lexical:V.36.38" data-filt="verse-overlap">
+    <header><div class="hw">√śap @ V.36.38 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма śape (mandara … meruṇā … dardureṇa)</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Sap|commentary:sundara-lexical:V.36.38</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Sap</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √śap — цитируется в аппарате на <code>commentary:sundara-lexical:V.36.38</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Шапе (śape, 1sg.pres. от √śap- «клясться») — «клянусь». Хануман даёт клятву, называя горы: Мандара, Малая, Виндхья, Меру, Дарда. В ведийской и эпической традиции клятва горой (parvata-śapatha) — один из сильнейших типов клятвы: горы вечны и незыблемы, их упоминание призывает svara вечности как свидетеля. Список гор не произволен: Мандара — ось мироздания (мантали-мандара), Меру — космическая гора,</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_36_38</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Baj|commentary:sundara-lexical:V.36.41" data-filt="verse-overlap">
+    <header><div class="hw">√bhaj @ V.36.41 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма vanya bhakta (pañcamam)</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Baj|commentary:sundara-lexical:V.36.41</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Baj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhaj — цитируется в аппарате на <code>commentary:sundara-lexical:V.36.41</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Ванья бхакта (vanya bhakta, n.) — «лесная пища», тат-пуруша: vanya «лесное, дикое» + bhakta «пища, еда» (от √bhaj-). Хануман говорит, что Рама «каждый день на пятой (трапезе) ест должным образом приготовленную лесную пищу (vanyaṃ suvihitaṃ bhaktam aśnāti pañcamam)». «Пятая трапеза» (pañcama bhakta) — технический термин аскетического питания: есть только раз в пять дней. Это форма tapas — доброволь</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_36_41</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kf|commentary:sundara-lexical:V.37.3" data-filt="verse-overlap">
+    <header><div class="hw">√kṛ @ V.37.3 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма kṛtānta</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kf|commentary:sundara-lexical:V.37.3</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.37.3</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Кританта (kṛtānta, m., букв. «делающий конец», kṛta- p.p.p. √kṛ- + anta «конец») — судьба, смерть, персонификация Ямы. MW: kṛtānta m. &#x27;fate; Yama (god of death); established rule&#x27;. Подстрочник «судьба» — нейтрально; но kṛtānta — не абстрактное понятие, а личная сила — «делатель конца»: образ существа, которое физически «тянет» человека верёвкой (rajjveva... parikarṣati).</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_37_3</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:BU|commentary:sundara-lexical:V.37.33" data-filt="verse-overlap">
+    <header><div class="hw">√bhū @ V.37.33 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма paribhava</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:BU|commentary:sundara-lexical:V.37.33</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:BU</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhū — цитируется в аппарате на <code>commentary:sundara-lexical:V.37.33</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Парибхава (paribhava, m.) — «унижение, оскорбление» (pari- + √bhū- «быть»): состояние, когда тебя «обходят кругом» / не принимают в расчёт. MW: paribhava m. &#x27;disrespect, contempt, humiliation&#x27;. Хануман воспринимает сомнение Ситы в его способности как «нового оскорбления» (navaṃ paribhavaṃ): интересно, что первая реакция — не обида, а философская оценка; nava («новый») подчёркивает, что это удивите</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_37_33</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:yat|commentary:sundara-lexical:V.37.60" data-filt="verse-overlap">
+    <header><div class="hw">√yat @ V.37.60 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма āyatta</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:yat|commentary:sundara-lexical:V.37.60</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:yat</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √yat — цитируется в аппарате на <code>commentary:sundara-lexical:V.37.60</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Аятта (āyatta, adj.) — «зависящий от, находящийся во власти» (ā + p.p.p. √yat- «прилагать усилие, достигать»). MW: āyatta adj. &#x27;resting on, depending on, subject to&#x27;. mayi jīvitam āyattam — «от меня зависит жизнь»: āyatta подчёркивает не просто связь, а структуру зависимости — жизнь Рамы и братьев буквально «стоит на» Хануману как на опоре. Мощная риторическая формула убеждения.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_37_60</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:i|commentary:sundara-lexical:V.38.21" data-filt="verse-overlap">
+    <header><div class="hw">√i @ V.38.21 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма paryāya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:i|commentary:sundara-lexical:V.38.21</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:i</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √i — цитируется в аппарате на <code>commentary:sundara-lexical:V.38.21</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Парьяя (paryāya, m.) — «чередование, очерёдность, цикл» (pari + √i- «идти»; paryāya букв. «обход кругом»). MW: paryāya m. &#x27;going round; revolution; regular order, turn&#x27;. paryāyeṇa prasuptaś ca — «в свою очередь заснул»: paryāya здесь = «поочерёдно». В āyurveda/kāvya paryāya также = «синоним» (слово, «обходящее вокруг» значения). Указывает на ритмически чередующийся сон — нежная интимная деталь эпи</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_38_21</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Sak|commentary:sundara-lexical:V.38.27" data-filt="verse-overlap">
+    <header><div class="hw">√śak @ V.38.27 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма śakra</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Sak|commentary:sundara-lexical:V.38.27</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Sak</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √śak — цитируется в аппарате на <code>commentary:sundara-lexical:V.38.27</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Шакра (Śakra, m.) — «могучий» (śakra adj. от √śak- «быть способным»): имя Индры как «могущественного». MW: Śakra m. &#x27;powerful; Indra&#x27;. Ворона — «сын Шакры» (putraḥ śakrasya): этот мотив объясняет её особые способности (быстрота, схожая с Ваю, и неуязвимость). Называние отца-Индры — нарративное обоснование того, почему brahmastra необходима против обычной вороны.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_38_27</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:tap|commentary:sundara-lexical:V.39.23" data-filt="verse-overlap">
+    <header><div class="hw">√tap @ V.39.23 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма paritāpa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:tap|commentary:sundara-lexical:V.39.23</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:tap</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √tap — цитируется в аппарате на <code>commentary:sundara-lexical:V.39.23</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Паритапа (pari-tāpa, m.) — «жжение/мука со всех сторон» (pari «вокруг, со всех сторон» + √tap- «жечь, нагревать»). MW: paritāpa m. &#x27;heat; pain, distress&#x27;. pari-tāpa — жар, который окружает со всех сторон. В тексте: tavādarśanajaḥ śoko māṃ paritāpayet «скорбь меня будет жечь». Образ связан с tapas (аскетический жар): Сита «горит» в аскезе разлуки.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_39_23</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:pad|commentary:sundara-lexical:V.39.33" data-filt="verse-overlap">
+    <header><div class="hw">√pad @ V.39.33 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма sattvasampanna</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:pad|commentary:sundara-lexical:V.39.33</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:pad</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √pad — цитируется в аппарате на <code>commentary:sundara-lexical:V.39.33</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Саттвасампанна (sattva-sampanna, adj.) — «обладающий (наделённый) саттвой» (sampanna p.p.p. sam-√pad- «приходить к»). MW: sampanna &#x27;accomplished, endowed with, having&#x27;. sattvasampanna применительно к Сугриве: не просто «отважный» (śūra), но наделённый сущностной энергией-саттвой, что в Sāṃkhya = первейшее из трёх качеств (guṇa). Хануман подбирает термин, соответствующий dharmic превосходству Сугри</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_39_33</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:jYA|commentary:sundara-lexical:V.40.4" data-filt="verse-overlap">
+    <header><div class="hw">√jñā @ V.40.4 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма abhijñāna</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:jYA|commentary:sundara-lexical:V.40.4</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:jYA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √jñā — цитируется в аппарате на <code>commentary:sundara-lexical:V.40.4</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Абхиджняна (abhijñāna, n.) — от abhi-√jñā- (класс IX, «знать, распознавать», Whitney #851) + суфф. деверб. -ana. MW: abhijñāna &#x27;recognition; a sign or token of recognition; a remembrance&#x27;. В эпосе abhijñāna — юридически-нарративный термин: предмет или знание, неопровержимо идентифицирующие личность, когда очная встреча невозможна. Именно это его значение ключево здесь: Сита просит Ханумана добыть </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_40_4</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:ah|commentary:sundara-lexical:V.42.9" data-filt="verse-overlap">
+    <header><div class="hw">√ah @ V.42.9 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма lokokti: ahir ahiṃ jānāti</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:ah|commentary:sundara-lexical:V.42.9</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:ah</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ah — цитируется в аппарате на <code>commentary:sundara-lexical:V.42.9</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>«Змея знает стопы змеи» (ahir eva hy aheḥ pādān vijānāti, V.42.9) — локовокти (lokokti, народная пословица), параллельная санскритскому субхашите. Прямой аналог: рус. «рыбак рыбака видит издалека». Применительно к ракшасам: только сами ракшасы, как оборотни-kāmarūpin, могут распознать оборотня среди своих. Пословица выполняет нарративную функцию: Сита отводит от себя ответственность за опознание —</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_42_9</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:i|commentary:sundara-lexical:V.42.9" data-filt="verse-overlap">
+    <header><div class="hw">√i @ V.42.9 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма lokokti: ahir ahiṃ jānāti</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:i|commentary:sundara-lexical:V.42.9</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:i</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √i — цитируется в аппарате на <code>commentary:sundara-lexical:V.42.9</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>«Змея знает стопы змеи» (ahir eva hy aheḥ pādān vijānāti, V.42.9) — локовокти (lokokti, народная пословица), параллельная санскритскому субхашите. Прямой аналог: рус. «рыбак рыбака видит издалека». Применительно к ракшасам: только сами ракшасы, как оборотни-kāmarūpin, могут распознать оборотня среди своих. Пословица выполняет нарративную функцию: Сита отводит от себя ответственность за опознание —</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_42_9</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kf|commentary:sundara-lexical:V.42.24" data-filt="verse-overlap">
+    <header><div class="hw">√kṛ @ V.42.24 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма kiṃkara</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kf|commentary:sundara-lexical:V.42.24</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.42.24</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Кимкара (kiṃ-kara, m.) — этимологический каламбур: kiṃ «что?» + kara m./adj. «делающий» (√kṛ-, «делать», Whitney #521). MW: kiṃkara &#x27;doing what? what is to be done? (a servant who is always asking what he is to do); a slave, servant&#x27;. Буквально: «делающий что прикажут», т. е. безвольный исполнитель. В мифологическом контексте: kiṃkarāḥ Ямы — слуги бога смерти, перечисляемые в Махабхарате (Ādiparva</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_42_24</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Df|commentary:sundara-lexical:V.43.18" data-filt="verse-overlap">
+    <header><div class="hw">√dhṛ @ V.43.18 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма śatadhāra</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Df|commentary:sundara-lexical:V.43.18</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Df</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.43.18</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Шатадхара (śata-dhāra, adj.) — «обладающий сотней острий», эпитет колонны (stambha), используемой как оружие. śata «сто» + dhārā «острие, лезвие, кромка» (√dhṛ «нести, держать» в значении «точёный край»). MW: dhāra &#x27;edge or blade of a sword&#x27;; śatadhāra &#x27;having 100 edges&#x27; — стандартный эпитет vajra (молнии-оружия Индры). Перебрасывая stambha-śatadhāra, Хануман имплицитно уподобляется Индре с его ва</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_43_18</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:tap|commentary:sundara-lexical:V.45.12" data-filt="verse-overlap">
+    <header><div class="hw">√tap @ V.45.12 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма paraṃtapa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:tap|commentary:sundara-lexical:V.45.12</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:tap</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √tap — цитируется в аппарате на <code>commentary:sundara-lexical:V.45.12</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Парантапа (paraṃ-tapa, adj./m.) — «сжигающий врагов»: para «иной, враг» (в Acc. paraṃ) + √tap- «жечь, пылать» (Whitney #182). MW: paraṃtapa &#x27;scorcher of foes — an epithet of heroes&#x27;. Это один из наиболее семантически насыщенных воинских эпитетов: герой уподобляется огню (tapas), а враги — его топливу. В V.45.12 paraṃtapa отнесено к Хануману именно в момент физической расправы (ладонями, ногами, ку</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_45_12</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vf|commentary:sundara-lexical:V.46.1" data-filt="verse-overlap">
+    <header><div class="hw">√vṛ @ V.46.1 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма saṃvṛtākāra</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vf|commentary:sundara-lexical:V.46.1</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.46.1</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Самврита-акара (saṃvṛta-ākāra, adj.) — бахуврихи: saṃvṛta «скрытый, прикрытый» (sam+√vṛ-, «покрывать», Whitney #728) + ākāra «внешний вид, выражение лица» (MW). MW: saṃvṛta &#x27;covered, concealed&#x27;; ākāra &#x27;form, expression of countenance&#x27;. Несёт специфически политическую семантику: скрыть выражение лица — один из базовых навыков раджанити. Ману (7.141) предписывает царю saṃvṛtāmantrin (тайный совет) и</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_46_1</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vid|commentary:sundara-lexical:V.46.27" data-filt="verse-overlap">
+    <header><div class="hw">√vid @ V.46.27 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма vidyudrāśi</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vid|commentary:sundara-lexical:V.46.27</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vid</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vid — цитируется в аппарате на <code>commentary:sundara-lexical:V.46.27</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Видьюд-раши (vidyut-rāśi, m.) — тат-пуруша: vidyut «молния» (√vid-, «сверкать/блестеть», MW) + rāśi «куча, масса» (√rāś-, «накапливаться»). MW: vidyut &#x27;lightning&#x27;; rāśi &#x27;heap, mass, multitude&#x27;. Образ vidyudrāśir girāv iva — «словно масса молний на гору» — строится на ведийской иконе грозы: не одна молния, а rāśi (множество, груда) молний одновременно. Усиление до абсолютной деструктивной мощи соот</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_46_27</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:car|commentary:sundara-lexical:V.47.5" data-filt="verse-overlap">
+    <header><div class="hw">√car @ V.47.5 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма asaṅgacārin</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:car|commentary:sundara-lexical:V.47.5</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:car</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √car — цитируется в аппарате на <code>commentary:sundara-lexical:V.47.5</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Асанга-чарин (asaṅga-cārin, adj.) — бахуврихи: asaṅga «без препятствий, без привязанностей» (a-+saṅga, √sañj-, «прилипать, задерживаться») + cārin «движущийся» (√car-, «двигаться»). MW: asaṅga &#x27;unattached, free from bonds&#x27;; cārin &#x27;going, moving&#x27;. Применительно к боевой колеснице asaṅgacārin означает «движущуюся без препятствий» — технически непреодолимую машину. Но за военным смыслом стоит йогичес</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_47_5</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:saYj|commentary:sundara-lexical:V.47.5" data-filt="verse-overlap">
+    <header><div class="hw">√sañj @ V.47.5 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма asaṅgacārin</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:saYj|commentary:sundara-lexical:V.47.5</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:saYj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sañj — цитируется в аппарате на <code>commentary:sundara-lexical:V.47.5</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Асанга-чарин (asaṅga-cārin, adj.) — бахуврихи: asaṅga «без препятствий, без привязанностей» (a-+saṅga, √sañj-, «прилипать, задерживаться») + cārin «движущийся» (√car-, «двигаться»). MW: asaṅga &#x27;unattached, free from bonds&#x27;; cārin &#x27;going, moving&#x27;. Применительно к боевой колеснице asaṅgacārin означает «движущуюся без препятствий» — технически непреодолимую машину. Но за военным смыслом стоит йогичес</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_47_5</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:cal|commentary:sundara-lexical:V.47.13" data-filt="verse-overlap">
+    <header><div class="hw">√cal @ V.47.13 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма acala</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:cal|commentary:sundara-lexical:V.47.13</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:cal</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √cal — цитируется в аппарате на <code>commentary:sundara-lexical:V.47.13</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Ачала (acala, m.) — «неподвижный, гора» (a-+√cal-, «двигаться»). MW: acala &#x27;immovable; a mountain&#x27;. Принципиально: в шлоке 13 acalaḥ pracacāla — «недвижимое задрожало». Это оксюморон с этимологическим ключом: acala по самой своей природе «не-двигающееся», и вот оно движется. Землетрясение при схватке Ханумана и Акши нарушает онтологический порядок: солнце гаснет, ветер стихает, гора содрогается. Н</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_47_13</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:BU|commentary:sundara-lexical:V.47.20" data-filt="verse-overlap">
+    <header><div class="hw">√bhū @ V.47.20 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма bālabhāva</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:BU|commentary:sundara-lexical:V.47.20</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:BU</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhū — цитируется в аппарате на <code>commentary:sundara-lexical:V.47.20</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Бала-бхава (bāla-bhāva, m.) — тат-пуруша: bāla «юный, неопытный» + bhāva «бытие, состояние» (√bhū-, «быть»). MW: bāla &#x27;young, childish&#x27;; bhāva &#x27;becoming, being; nature, disposition&#x27;. Bālabhāvād — «из-за [своего] состояния юности» — содержит амбивалентность: юность делает Акшу vīryadarpita (гордым доблестью), что положительно (кшатрийская смелость), но и уязвимым для переоценки себя. Это типичный э</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_47_20</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vfD|commentary:sundara-lexical:V.47.29" data-filt="verse-overlap">
+    <header><div class="hw">√vṛdh @ V.47.29 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма vardhamānāgni</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vfD|commentary:sundara-lexical:V.47.29</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vfD</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vṛdh — цитируется в аппарате на <code>commentary:sundara-lexical:V.47.29</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Вардхаман-агни (vardhāmāna-agni, m.) — «разгорающийся огонь». Vardhamāna — причастие настоящего времени от √vṛdh- («возрастать, разгораться», Whitney #834). Хануман использует этот образ в внутреннем монологе: vardhamāno &#x27;gnir upekṣituṃ na kṣamaḥ — «разгорающийся огонь нельзя не замечать». Это прямая цитата из нитишастры — максима государственного управления: врага (как огонь) следует гасить в зар</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_47_29</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:rakz|commentary:sundara-lexical:V.48.1" data-filt="verse-overlap">
+    <header><div class="hw">√rakṣ @ V.48.1 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма rakṣo&amp;#x27;dhipati</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:rakz|commentary:sundara-lexical:V.48.1</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:rakz</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √rakṣ — цитируется в аппарате на <code>commentary:sundara-lexical:V.48.1</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Ракшо-&#x27;дхипати (rakṣas-adhipati, m.) — тат-пуруша: rakṣas «ракшас» (от √rakṣ-, «охранять / вредить», MW: rakṣas &#x27;an evil spirit, demon&#x27;) + adhipati «владыка, верховный повелитель» (adhi- «над» + pati «господин»). Этот эпитет в той же шлоке соседствует с mahātmā — «великий духом» (mahā+ātman). Juxtaposition «владыка ракшасов» + «великий духом» нарушает ожидание: mahātman в эпосе — почётный титул бо</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_48_1</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:ru|commentary:sundara-lexical:V.50.1" data-filt="verse-overlap">
+    <header><div class="hw">√ru @ V.50.1 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма lokarāvaṇa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:ru|commentary:sundara-lexical:V.50.1</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:ru</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ru — цитируется в аппарате на <code>commentary:sundara-lexical:V.50.1</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Локаравана (loka-rāvaṇa, m.) — «тот, чей рёв слышен во всех мирах», народная этимология имени Равана (Rāvaṇa). MW: rāvaṇa &#x27;causing to cry, causing to lament&#x27;; от √ru-/√rav- (класс II, Whitney #396, «реветь, кричать») + суфф. -ana. Здесь стих обыгрывает это: «rāvaṇo lokarāvaṇaḥ» — «Равана, чей рёв — во всём мире». Парономасия: имя собственное Rāvaṇa эксплицируется через нарицательное loka-rāvaṇa — </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_50_1</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:diS|commentary:sundara-lexical:V.51.2" data-filt="verse-overlap">
+    <header><div class="hw">√diś @ V.51.2 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма saṃdeśa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:diS|commentary:sundara-lexical:V.51.2</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:diS</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √diś — цитируется в аппарате на <code>commentary:sundara-lexical:V.51.2</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Сандеша (saṃdeśa, m.) — «послание, повеление, инструкция»; от sam-diś- (√diś-, «указывать, направлять»). MW: saṃdeśa &#x27;information, instruction, order, message&#x27;. Saṃdeśa отличается от sandhi (союз), sevā (служение) и vara (дар): это именно формальный дипломатический мандат, делегирующий говорящему полномочия принципала. Хануман: «ahaṃ sugrīva-saṃdeśād» — «я (пришёл) по saṃdeśa Сугривы» = с дипломат</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_51_2</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kIrt|commentary:sundara-lexical:V.51.23" data-filt="verse-overlap">
+    <header><div class="hw">√kīrt @ V.51.23 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма kīrti</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kIrt|commentary:sundara-lexical:V.51.23</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kIrt</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kīrt — цитируется в аппарате на <code>commentary:sundara-lexical:V.51.23</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Кирти (kīrti, f.) — «слава, известность»; от √kṝt- / √kīrt- («упоминать, прославлять»). MW: kīrti &#x27;fame, renown, glory&#x27;. Kīrti отличается от yaśas: yaśas — «лучезарная слава» (сияние добродетели), kīrti — «слава через упоминание» (люди называют имя). В эпической этике потеря kīrti = смерть при жизни. Хануман предупреждает Равану: возврат Ситы восстановит его kīrti; отказ — уничтожит. Различение kī</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_51_23</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:DA|commentary:sundara-lexical:V.53.1" data-filt="verse-overlap">
+    <header><div class="hw">√dhā @ V.53.1 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма daśakālahita</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:DA|commentary:sundara-lexical:V.53.1</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:DA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhā — цитируется в аппарате на <code>commentary:sundara-lexical:V.53.1</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Деша-кала-хита (deśa-kāla-hita, adj.) — тройной тат-пуруша: deśa «место» + kāla «время» + hita (p.p.p. от √dhā- или adj. «полезный, благоприятный») = «соответствующее месту и времени». MW: hita &#x27;placed; salutary, wholesome&#x27;. Это устойчивая формула разумной речи в эпическом дискурсе — речь «соответствующая месту и времени» — deśakālahita — противопоставлена речи импульсивной. Формула маркирует сове</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_53_1</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:aS|commentary:sundara-lexical:V.53.26" data-filt="verse-overlap">
+    <header><div class="hw">√aś @ V.53.26 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма hutāśana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:aS|commentary:sundara-lexical:V.53.26</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:aS</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √aś — цитируется в аппарате на <code>commentary:sundara-lexical:V.53.26</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Хуташа (hutāśana, m.) — «пожиратель жертв», архаический эпитет огня: huta (p.p.p. от √hu-, «совершать жертвоприношение», класс III, Whitney #660) + aśana («поедание», от √aś-/aśana «пища»). MW: hutāśana &#x27;fire (as devouring oblations)&#x27;. Это ведийское имя агни как ритуальной функции — агни получает жертву (haviṣ, ghṛta) и «поедает» её. Когда Сита обращается к hutāśana — она апеллирует к огню именно </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_53_26</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:hu|commentary:sundara-lexical:V.53.26" data-filt="verse-overlap">
+    <header><div class="hw">√hu @ V.53.26 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма hutāśana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:hu|commentary:sundara-lexical:V.53.26</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:hu</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √hu — цитируется в аппарате на <code>commentary:sundara-lexical:V.53.26</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Хуташа (hutāśana, m.) — «пожиратель жертв», архаический эпитет огня: huta (p.p.p. от √hu-, «совершать жертвоприношение», класс III, Whitney #660) + aśana («поедание», от √aś-/aśana «пища»). MW: hutāśana &#x27;fire (as devouring oblations)&#x27;. Это ведийское имя агни как ритуальной функции — агни получает жертву (haviṣ, ghṛta) и «поедает» её. Когда Сита обращается к hutāśana — она апеллирует к огню именно </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_53_26</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:aYj|commentary:sundara-lexical:V.54.37" data-filt="verse-overlap">
+    <header><div class="hw">√añj @ V.54.37 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма avyakta</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:aYj|commentary:sundara-lexical:V.54.37</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:aYj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √añj — цитируется в аппарате на <code>commentary:sundara-lexical:V.54.37</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Авьякта (avyakta, adj./n.) — «непроявленное», от a- + vyakta (p.p.p. от vi-√añj- / vi-√aj-, «проявлять, выявлять»). MW: avyakta &#x27;undeveloped, not manifest; the unmanifest (in Sāṃkhya: primordial matter)&#x27;. В системе Санкхьи avyakta — пракрити в непроявленном состоянии, предшествующем творению. Стих 54.37 даёт четыре апофатических атрибута Вишну: acintyam («непостижимое») + avyaktam («непроявленное»</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_54_37</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:aj|commentary:sundara-lexical:V.54.37" data-filt="verse-overlap">
+    <header><div class="hw">√aj @ V.54.37 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма avyakta</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:aj|commentary:sundara-lexical:V.54.37</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:aj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √aj — цитируется в аппарате на <code>commentary:sundara-lexical:V.54.37</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Авьякта (avyakta, adj./n.) — «непроявленное», от a- + vyakta (p.p.p. от vi-√añj- / vi-√aj-, «проявлять, выявлять»). MW: avyakta &#x27;undeveloped, not manifest; the unmanifest (in Sāṃkhya: primordial matter)&#x27;. В системе Санкхьи avyakta — пракрити в непроявленном состоянии, предшествующем творению. Стих 54.37 даёт четыре апофатических атрибута Вишну: acintyam («непостижимое») + avyaktam («непроявленное»</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_54_37</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:riz|commentary:sundara-lexical:V.56.26" data-filt="verse-overlap">
+    <header><div class="hw">√riṣ @ V.56.26 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма ariṣṭa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:riz|commentary:sundara-lexical:V.56.26</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:riz</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √riṣ — цитируется в аппарате на <code>commentary:sundara-lexical:V.56.26</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Аришта (ariṣṭa, adj./n.) — «невредимый; вещун; дерево neem», от a- (отриц.) + √riṣ- («вредить»). MW: ariṣṭa &#x27;unhurt; a raven or crow (as a bird of ill omen); the nim-tree&#x27;. Название горы Ariṣṭa («не знающий вреда, нетронутый») — апотропеическая семантика: гора, неуязвимая для любого вреда. Одновременно ariṣṭa — «предзнаменование» (особенно дурное, от вороны) и дерево neem (Azadirachta indica), кот</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_56_26</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Sak|commentary:sundara-lexical:V.56.44" data-filt="verse-overlap">
+    <header><div class="hw">√śak @ V.56.44 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма śakrāyudha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Sak|commentary:sundara-lexical:V.56.44</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Sak</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √śak — цитируется в аппарате на <code>commentary:sundara-lexical:V.56.44</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Шакраюдха (śakra-āyudha, n.) — «оружие Индры» = радуга: śakra «мощный» (эпитет Индры, от √śak-, «быть способным, мощным») + āyudha «оружие» (ā+√yudh-, «сражаться»). MW: śakrāyudha &#x27;Indra&#x27;s weapon, the rainbow&#x27;. Деревья, сломанные Хануманом, сравниваются с «поражёнными оружием Индры», т.е. ударом молнии/радуги. Śakrāyudha как «радуга» — образ, восходящий к РВ: Парджанья (дождевое облако) метает мол</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_56_44</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:yuD|commentary:sundara-lexical:V.56.44" data-filt="verse-overlap">
+    <header><div class="hw">√yudh @ V.56.44 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма śakrāyudha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:yuD|commentary:sundara-lexical:V.56.44</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:yuD</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √yudh — цитируется в аппарате на <code>commentary:sundara-lexical:V.56.44</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Шакраюдха (śakra-āyudha, n.) — «оружие Индры» = радуга: śakra «мощный» (эпитет Индры, от √śak-, «быть способным, мощным») + āyudha «оружие» (ā+√yudh-, «сражаться»). MW: śakrāyudha &#x27;Indra&#x27;s weapon, the rainbow&#x27;. Деревья, сломанные Хануманом, сравниваются с «поражёнными оружием Индры», т.е. ударом молнии/радуги. Śakrāyudha как «радуга» — образ, восходящий к РВ: Парджанья (дождевое облако) метает мол</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_56_44</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vI|commentary:sundara-lexical:V.57.39" data-filt="verse-overlap">
+    <header><div class="hw">√vī @ V.57.39 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма ekkaveṇī</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vI|commentary:sundara-lexical:V.57.39</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vI</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vī — цитируется в аппарате на <code>commentary:sundara-lexical:V.57.39</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Экавени (eka-veṇī, f.) — «одна коса, единственная коса», от eka «один» + veṇī «заплетённая коса» (√vī- / √van-, MW: veṇī &#x27;a braid or plait of hair&#x27;). В традиции индийской женской обрядности замужняя женщина носит волосы заплетёнными в две косы или убранными в причёску; «одна коса» (ekaveṇī) — особый статус: это прическа вдовства или невыносимого горя, которую Драупади носила до отмщения за унижени</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_57_39</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:tap|commentary:sundara-lexical:V.59.3" data-filt="verse-overlap">
+    <header><div class="hw">√tap @ V.59.3 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма tapas (śakti)</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:tap|commentary:sundara-lexical:V.59.3</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:tap</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √tap — цитируется в аппарате на <code>commentary:sundara-lexical:V.59.3</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Тапас как оружие (tapasā dhārayel lokān kruddhā vā nirdahed api) — «тапасом может она поддерживать вселенную или в гневе сжечь её». Тапас (tapas, n.) от √tap- (класс I, Whitney #182, «жечь, пылать»): аскетический жар, накапливаемый благочестием. MW: tapas &#x27;warmth; religious austerity; supernatural power acquired by austerity&#x27;. В дхармашастрах и эпосе tapa-śakti — сила, способная аннулировать и под</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_59_3</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:as|commentary:sundara-lexical:V.59.10" data-filt="verse-overlap">
+    <header><div class="hw">√as @ V.59.10 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма astraṃ brāhmaṃ</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:as|commentary:sundara-lexical:V.59.10</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:as</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √as — цитируется в аппарате на <code>commentary:sundara-lexical:V.59.10</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Брахмастра (brahma-astra, n.) — «оружие [бога] Брахмы»: brahma «Брахма» + astra «метательное оружие» (√as-, «бросать», n. с суфф. -tra). MW: astra &#x27;a missile weapon, arrow&#x27;. В стихе Хануман называет четыре категории астр: brahma (Брахмы), raudra (Рудры/Шивы), vāyavya (Ваю) и vāruṇa (Варуны). Астра — не физическая стрела, а наведённое сверхъестественной мантрой оружие, поражающее на любом расстояни</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_59_10</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:liK|commentary:sundara-lexical:V.59.22" data-filt="verse-overlap">
+    <header><div class="hw">√likh @ V.59.22 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма megharekhā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:liK|commentary:sundara-lexical:V.59.22</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:liK</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √likh — цитируется в аппарате на <code>commentary:sundara-lexical:V.59.22</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Мегхарекха (megha-rekhā, f.) — «облачная полоска, нить облака»: megha «облако» (√mih-, «мочиться; туманиться», с чередованием) + rekhā «линия, полоска» (√likh-, «царапать, чертить»). MW: rekhā &#x27;a line, streak&#x27;. В стихе Сита уподоблена луне, затянутой полоской облака (megharekhāparivṛtā candralekheva niṣprabhā). Megha-rekhā — именно тонкая полоска облака, а не тучи; candralekhā — «серп луны» (реха </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_59_22</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:pad|commentary:sundara-lexical:V.59.31" data-filt="verse-overlap">
+    <header><div class="hw">√pad @ V.59.31 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма pratipat</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:pad|commentary:sundara-lexical:V.59.31</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:pad</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √pad — цитируется в аппарате на <code>commentary:sundara-lexical:V.59.31</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Пратипат (pratipat, f.) — «первый день [лунной] половины месяца» (prathamā tithi pakṣasya): prati «против, обратно» + √pad- «идти». MW: pratipat &#x27;the first day of a lunar fortnight&#x27;. В сравнении: «śīla знания того, кто изучает (Веды) в первый день половины» = в день pratipat луна/Веды только начинают прибывать. Tanūtā (истощение) Ситы сравнивается с «тонкостью» только что нарождающегося лунного се</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_59_31</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vft|commentary:sundara-lexical:V.61.5" data-filt="verse-overlap">
+    <header><div class="hw">√vṛt @ V.61.5 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма arthanirvṛtti</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vft|commentary:sundara-lexical:V.61.5</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vft</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vṛt — цитируется в аппарате на <code>commentary:sundara-lexical:V.61.5</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Артханирврити (artha-nirvṛtti, f.) — тат-пуруша: artha «цель, дело, смысл» + nirvṛtti (ni+√vṛt-, «вращаться, возвращаться к исходному состоянию»; MW: nirvṛtti &#x27;cessation, completion, accomplishment&#x27;). Техническое значение в контексте посольства (dūtya): nirvṛtti означает не просто «успех», но достижение состояния завершённости — когда дело вернулось к исходной точке равновесия (ni- = «вниз, к осно</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_61_5</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vac|commentary:sundara-lexical:V.61.20" data-filt="verse-overlap">
+    <header><div class="hw">√vac @ V.61.20 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма dadhivaktra</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vac|commentary:sundara-lexical:V.61.20</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vac</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vac — цитируется в аппарате на <code>commentary:sundara-lexical:V.61.20</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Дадхивактра (dadhi-vaktra, m.) — бахуврихи: dadhi «простокваша, створоженное молоко» + vaktra «лицо, рот» (√vac-, «говорить»). Вариантный эпитет стража леса, которого в гл. 9 этой же главы называют Дадхимукха (dadhi-mukha, то же значение: mukha = «лицо, рот»). MW: dadhi &#x27;coagulated milk, curd&#x27;. Зоонимическая логика: морда или мордочка светло-жёлтого, «молочного» цвета — обычная черта окраски некот</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_61_20</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:sfj|commentary:sundara-lexical:V.62.7" data-filt="verse-overlap">
+    <header><div class="hw">√sṛj @ V.62.7 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма atisarga</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:sfj|commentary:sundara-lexical:V.62.7</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:sfj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sṛj — цитируется в аппарате на <code>commentary:sundara-lexical:V.62.7</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Атисарга (ati-sarga, m.) — «особое разрешение, снятие запрета»: ati («сверх, превыше») + sarga («отпускание, дозволение», √sṛj- «выпускать»). MW: atisarga &#x27;special permission&#x27;. В стихе «atisargāc ca paṭavo» — «раззадоренные [полученным] дозволением». Ключевой термин: войску разрешено пить и наслаждаться лесом не по праву, а по особому atisarga. Концепция atisarga в дхармашастрах описывает временно</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_62_7</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:dA|commentary:sundara-lexical:V.62.17" data-filt="verse-overlap">
+    <header><div class="hw">√dā @ V.62.17 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма dattavara</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:dA|commentary:sundara-lexical:V.62.17</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:dA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dā — цитируется в аппарате на <code>commentary:sundara-lexical:V.62.17</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Даттавара (datta-vara, adj./m.) — «[тот, кому] дан дар, наделённый благодатью»: datta (p.p.p. от √dā-, «давать») + vara «дар, благодать, выбор» (от √vṛ-, «выбирать»). MW: vara &#x27;choosing; a boon, benefit; the best of its kind&#x27;. В стихе «hanūmatā dattavarair hataṃ madhuvanaṃ balāt» — «с позволения (с даром от) Ханумана силой разорен лес». Dattavara здесь имеет особый юридический смысл: подразумевает</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_62_17</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vf|commentary:sundara-lexical:V.62.17" data-filt="verse-overlap">
+    <header><div class="hw">√vṛ @ V.62.17 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма dattavara</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vf|commentary:sundara-lexical:V.62.17</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.62.17</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Даттавара (datta-vara, adj./m.) — «[тот, кому] дан дар, наделённый благодатью»: datta (p.p.p. от √dā-, «давать») + vara «дар, благодать, выбор» (от √vṛ-, «выбирать»). MW: vara &#x27;choosing; a boon, benefit; the best of its kind&#x27;. В стихе «hanūmatā dattavarair hataṃ madhuvanaṃ balāt» — «с позволения (с даром от) Ханумана силой разорен лес». Dattavara здесь имеет особый юридический смысл: подразумевает</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_62_17</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:f|commentary:sundara-lexical:V.62.26" data-filt="verse-overlap">
+    <header><div class="hw">√ṛ @ V.62.26 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма āryaka</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:f|commentary:sundara-lexical:V.62.26</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:f</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.62.26</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Арьяка (āryaka, m.) — «почтенный [дед/прадед]»: āryaka = уважительная форма от ārya («благородный, ариец», от √ṛ-, «двигаться, прибывать»), суффикс -ka с уменьшительно-ласкательно-почтительным оттенком. MW: āryaka &#x27;a respectable man; grandfather&#x27;. В стихе «madāndho na kṛpāṃ cakre āryako&#x27;yam mameti» — «опьянённый [Ангада] не сжалился [над Дадхимукхой], [думая]: это же мой āryaka (дед)». Āryaka — сп</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_62_26</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:aYj|commentary:sundara-lexical:V.62.38" data-filt="verse-overlap">
+    <header><div class="hw">√añj @ V.62.38 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма añjali</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:aYj|commentary:sundara-lexical:V.62.38</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:aYj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √añj — цитируется в аппарате на <code>commentary:sundara-lexical:V.62.38</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Анджали (añjali, m.) — «почтительно сложенные ладони», от √añj- («мазать, украшать, придавать форму»): две ладони, сложенные вместе в форме чаши-лодочки. MW: añjali &#x27;a mark of respect; the two hands joined&#x27;. Śirasi añjalim kṛtvā — «сложив ладони на голове» = наивысшая форма почтения (añjali поднят до уровня макушки, а не просто сложен перед грудью). Три уровня añjali в традиции: грудь (равные), го</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_62_38</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Sak|commentary:sundara-lexical:V.63.32" data-filt="verse-overlap">
+    <header><div class="hw">√śak @ V.63.32 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма śākhāmṛga</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Sak|commentary:sundara-lexical:V.63.32</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Sak</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √śak — цитируется в аппарате на <code>commentary:sundara-lexical:V.63.32</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>«Шакхамрига» (śākhāmṛga, m.) — «зверь ветвей» = обезьяна: śākhā «ветвь» (от √śak-, «мочь, нести»?) + mṛga «зверь, странник» (от √mṛg-, «преследовать, искать», Whitney #1426). MW: mṛga &#x27;any game or wild animal; a deer; a monkey&#x27; [последнее в числе значений]. Śākhāmṛga — поэтический кеннинг, употребляемый исключительно в высоком стиле; стандартные слова для обезьяны — vānara («лесной»), kapi, plavaṃ</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_63_32</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:dfp|commentary:sundara-lexical:V.63.32" data-filt="verse-overlap">
+    <header><div class="hw">√dṛp @ V.63.32 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма mṛgarājadarpā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:dfp|commentary:sundara-lexical:V.63.32</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:dfp</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dṛp — цитируется в аппарате на <code>commentary:sundara-lexical:V.63.32</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>«Мригараджадарпа» (mṛgarāja-darpa, adj. bah.) — «исполненные гордости льва»: mṛgarāja «царь зверей» = лев (не олень!) + darpa «высокомерие, гордость» (от √dṛp-, «безумствовать от гордости», Whitney #857). MW: mṛgarāja &#x27;the lion or tiger (king of beasts)&#x27;. Семантика mṛga здесь — капкан: в большинстве контекстов mṛga = «олень»; mṛgarāja = «царь оленей» было бы абсурдом. Но MW s.v. mṛga фиксирует и з</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_63_32</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:jYA|commentary:sundara-lexical:V.64.6" data-filt="verse-overlap">
+    <header><div class="hw">√jñā @ V.64.6 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма ajñāna</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:jYA|commentary:sundara-lexical:V.64.6</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:jYA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √jñā — цитируется в аппарате на <code>commentary:sundara-lexical:V.64.6</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Аджняна (a-jñāna, n.) — «неведение, незнание», a- (отрицательный префикс) + jñāna (√jñā-, «знать», Whitney #681). MW: ajñāna &#x27;ignorance&#x27;. В дхармашастровом дискурсе ajñāna — смягчающее обстоятельство: действие, совершённое по незнанию (ajñānāt), влечёт меньшую ответственность, чем умышленное. Дадхимукха выстраивает юридически корректную апологию: стражники действовали из невежества (ajñānāt), а не</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_64_6</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:car|commentary:sundara-lexical:V.64.10" data-filt="verse-overlap">
+    <header><div class="hw">√car @ V.64.10 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма vanacārin</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:car|commentary:sundara-lexical:V.64.10</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:car</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √car — цитируется в аппарате на <code>commentary:sundara-lexical:V.64.10</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Ванача́рин (vana-cārin, m./adj.) — тат-пуруша: vana «лес» + cārin (√car-, «двигаться, бродить», Whitney #615) = «бродящий по лесу». MW: vanacāra &#x27;living in a forest&#x27;. Vana в ведийской и эпической традиции — пространство, находящееся вне социального порядка (grāma), пространство аскезы и первобытной силы. Vanacārin = существа леса, не подчинённые городскому дхарма-порядку — это их свойство и их дха</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_64_10</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:tarj|commentary:sundara-lexical:V.65.3" data-filt="verse-overlap">
+    <header><div class="hw">√tarj @ V.65.3 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×2</span><span class="badge">лемма tarjana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:tarj|commentary:sundara-lexical:V.65.3</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:tarj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √tarj — цитируется в аппарате на <code>commentary:sundara-lexical:V.65.3</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Тарджана (tarjana, n.) — «угроза, устрашение», от √tarj- («угрожать, грозить пальцем»). MW: tarjana &#x27;threatening, menacing&#x27;. Глагол √tarj- описывает именно вербально-жестовую угрозу — звуком и жестом — в отличие от прямого физического воздействия. Ракшасини угрожают Сите тарджаной — регулярной, систематической. В арсенале давления на пленника тарджана есть отдельная техника: сломать дух, не трогая</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_65_3</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:uc|commentary:sundara-lexical:V.66.13" data-filt="verse-overlap">
+    <header><div class="hw">√uc @ V.66.13 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма sukhocitā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:uc|commentary:sundara-lexical:V.66.13</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:uc</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √uc — цитируется в аппарате на <code>commentary:sundara-lexical:V.66.13</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Сукхочита (sukha-ucitā, f.) — «привыкшая к счастью», sukha «счастье, удобство» + ucita (p.p.p. от √uc- «привыкать, находить приятным»). MW: ucita &#x27;accustomed to; suitable&#x27;. Sukha: пара sukha/duḥkha имеет «колесничную» этимологию (su-kha = «хорошее ступичное отверстие» ↔ duḥ-kha = «плохое ступичное отверстие»). Сита sukhocitā — «привыкшая к хорошей оси» — теперь вынуждена терпеть duḥkha. Это усилив</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_66_13</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:pat|commentary:sundara-lexical:V.67.10" data-filt="verse-overlap">
+    <header><div class="hw">√pat @ V.67.10 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма patatāṃ vara</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:pat|commentary:sundara-lexical:V.67.10</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:pat</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √pat — цитируется в аппарате на <code>commentary:sundara-lexical:V.67.10</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Patatāṃ вара (patatāṃ varaḥ) — «лучший из летающих», родительный падеж мн.ч. от √pat- («лететь», Whitney #191) + vara «лучший, избранный» (√vṛ-, Whitney #612). Стандартный эпический эпитет птиц; здесь применён к вороне — сыну Индры. Формула patatāṃ vara в позиции апозиции к vāyasaḥ («ворона») создаёт разрыв между ничтожностью птицы-вредителя и её божественным происхождением: ворона одновременно «н</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_67_10</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vf|commentary:sundara-lexical:V.67.10" data-filt="verse-overlap">
+    <header><div class="hw">√vṛ @ V.67.10 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма patatāṃ vara</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vf|commentary:sundara-lexical:V.67.10</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.67.10</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Patatāṃ вара (patatāṃ varaḥ) — «лучший из летающих», родительный падеж мн.ч. от √pat- («лететь», Whitney #191) + vara «лучший, избранный» (√vṛ-, Whitney #612). Стандартный эпический эпитет птиц; здесь применён к вороне — сыну Индры. Формула patatāṃ vara в позиции апозиции к vāyasaḥ («ворона») создаёт разрыв между ничтожностью птицы-вредителя и её божественным происхождением: ворона одновременно «н</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_67_10</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:BAz|commentary:sundara-lexical:V.67.33" data-filt="verse-overlap">
+    <header><div class="hw">√bhāṣ @ V.67.33 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма bāṣpagadgadabhāṣiṇī</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:BAz|commentary:sundara-lexical:V.67.33</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:BAz</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhāṣ — цитируется в аппарате на <code>commentary:sundara-lexical:V.67.33</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Башпагадгадабхашини (bāṣpa-gadgada-bhāṣiṇī, f.) — три-членный бахуврихи: bāṣpa «слезы» (MW: bāṣpa &#x27;tears, a tear&#x27;) + gadgada «заикающийся, прерывистый» (MW: gadgada &#x27;stammering, faltering&#x27;) + bhāṣiṇī «говорящая» (от √bhāṣ-, «говорить»). Gadgada — звукоподражательное слово, передающее физиологию рыдания: задыхание, прерывистость, невозможность удержать связную речь. Термин используется как иконичес</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_67_33</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:sAD|commentary:sundara-lexical:V.68.11" data-filt="verse-overlap">
+    <header><div class="hw">√sādh @ V.68.11 <span class="badge">➕ стих уже покрыт, корень не тронут</span><span class="badge">evidence ×1</span><span class="badge">лемма parisādhana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:sAD|commentary:sundara-lexical:V.68.11</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:sAD</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sādh — цитируется в аппарате на <code>commentary:sundara-lexical:V.68.11</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Парисадхана (pari-sādhana, n.) — «полное осуществление, завершение», pari- (усилительная приставка «кругом, вокруг, полностью») + sādhana (√sādh-, «достигать, совершать», Whitney #224). MW: sādhana &#x27;accomplishment, performance; a means of accomplishing&#x27;. Pari-sādhana — не просто «выполнение», а завершение в полной мере, без остатка. Сита говорит: kāmam asya tvam evaikaḥ kāryasya parisādhane / pary</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>➕ стих уже покрыт, корень не тронут — пересечения: comment_68_11</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:aYj|commentary:sundara-lexical:V.1.15" data-filt="unique-vs-1058">
+    <header><div class="hw">√añj @ V.1.15 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма añjana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:aYj|commentary:sundara-lexical:V.1.15</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:aYj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √añj — цитируется в аппарате на <code>commentary:sundara-lexical:V.1.15</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Сурьма (añjana) — букв.: «то, чем натирают», от корня añj- «мазать»; чёрный минеральный пигмент (антимонит), традиционный в Индии коллирий для подведения глаз. В тройном сложении «золото — сурьма — серебро» (kāñcana-añjana-rājata) даёт контраст золотого, чёрного и серебряного.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Df|commentary:sundara-lexical:V.1.201" data-filt="unique-vs-1058">
+    <header><div class="hw">√dhṛ @ V.1.201 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма dhṛti</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Df|commentary:sundara-lexical:V.1.201</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Df</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.1.201</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Стойкость (dhṛti) — от корня dhṛ- «держать»: твёрдость воли, выдержка. Первая в четвёрке добродетелей стиха: dhṛti «стойкость», dṛṣṭi «зоркость», mati «разум», dākṣya «ловкость» — Синхика побеждена именно ими, а не телесной мощью.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:yuj|commentary:sundara-lexical:V.2.3" data-filt="unique-vs-1058">
+    <header><div class="hw">√yuj @ V.2.3 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма yojana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:yuj|commentary:sundara-lexical:V.2.3</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:yuj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √yuj — цитируется в аппарате на <code>commentary:sundara-lexical:V.2.3</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Йоджана (yojana) — MW: yojana — «yoking, harnessing; a measure of distance (= 4 kroṣas or about 9 English miles, but some put it at 5 miles)». Букв. «запряжка» (от √yuj «запрягать») → расстояние одного перегона упряжки. В V.2.3 yojanānāṃ śataṃ śrīmāṃs tīrtvāpy uttamavikramaḥ — «переправившись через сто йоджан». 100 йоджан = ~800-900 км (по MW) или ~500 км (по нек. источникам). Yojana как «расстоян</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kf|commentary:sundara-lexical:V.2.16" data-filt="unique-vs-1058">
+    <header><div class="hw">√kṛ @ V.2.16 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма prākāra</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kf|commentary:sundara-lexical:V.2.16</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.2.16</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Крепостная стена (prākāra) — букв.: «[то, что] сделано вокруг», от корня kṛ- «делать» с приставками pra-ā-. Внешняя стена укреплённого города в отличие от вала у её подножия и внутренней ограды дворца. Золотая стена — постоянная примета Ланки как «золотого города»; ср. V. 3. 6, где та же стена названа сделанной из золота шатакумбха.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:su|commentary:sundara-lexical:V.6.42" data-filt="unique-vs-1058">
+    <header><div class="hw">√su @ V.6.42 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма madhvāsava</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:su|commentary:sundara-lexical:V.6.42</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:su</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √su — цитируется в аппарате на <code>commentary:sundara-lexical:V.6.42</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Мадхвасава (madhu-āsava, m.) — «медовое вино / хмельной напиток из мёда»: madhu «мёд, медовый напиток» + āsava «дистиллят, перебродивший напиток» (√su- «выжимать, дистиллировать»). MW: āsava &#x27;a spirituous liquor, spirit distilled from flowers, syrup or molasses&#x27;. Madhvāsava — конкретный тип напитка, отличный от surā (зерновая водка), varuni (финиковая) и soma (ритуальный). Мёд (madhu) в Ведах — са</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:yuj|commentary:sundara-lexical:V.9.2" data-filt="unique-vs-1058">
+    <header><div class="hw">√yuj @ V.9.2 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма yojana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:yuj|commentary:sundara-lexical:V.9.2</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:yuj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √yuj — цитируется в аппарате на <code>commentary:sundara-lexical:V.9.2</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Йоджана (yojana, n.) — «упряжка», мера расстояния: √yuj- («запрягать») → yojana «дистанция одной запряжки» (сколько проезжает упряжка без отдыха). MW: yojana &#x27;the distance traversed in one harnessing or without unyoking; a distance of 4 krośas (= about 9 miles or nearly 15 km)&#x27;. Размер варьируется по источнику: в Артхашастре 1 yojana = 4 krośa = 8000 dhanu. В Сундараканде размеры дворца Раваны — a</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:DU|commentary:sundara-lexical:V.9.27" data-filt="unique-vs-1058">
+    <header><div class="hw">√dhū @ V.9.27 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма aguru</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:DU|commentary:sundara-lexical:V.9.27</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:DU</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhū — цитируется в аппарате на <code>commentary:sundara-lexical:V.9.27</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Агуру (aguru, n./m.) — алоэ-дерево (Aquilaria agallocha / A. malaccensis), один из ценнейших ароматических материалов древней Индии. MW: aguru &#x27;not heavy; the fragrant Aloe wood&#x27;. Апте: &#x27;the Agallochum tree (Aquilaria Agallocha)&#x27;. Этимология народная: a+guru = «нетяжёлый» (древесина смоляных сортов алоэ тонет — вопреки названию). Aguru-dhūpa («воскуривание агуру») — стандартный ритуальный и придво</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:tap|commentary:sundara-lexical:V.11.4" data-filt="unique-vs-1058">
+    <header><div class="hw">√tap @ V.11.4 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма tapasvinī</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:tap|commentary:sundara-lexical:V.11.4</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:tap</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √tap — цитируется в аппарате на <code>commentary:sundara-lexical:V.11.4</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Тапасвини (tapasvinī, f.) — «обладающая тапасом», от √tap- (класс I, «жечь, пылать», Whitney #182) → tapas n. «жар аскезы» + суфф. -vin- (признак постоянного обладания). MW: tapasvin &#x27;practicing austerity; wretched&#x27;. Суффикс -vin- принципиально отличает этот эпитет от tapasā («тапасом», инстр.) — tapasvinī означает конституционального носителя тапаса. Здесь Сита воспринимается Хануманом как аскетк</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Suc|commentary:sundara-lexical:V.12.25" data-filt="unique-vs-1058">
+    <header><div class="hw">√śuc @ V.12.25 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма śokopahatacetana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Suc|commentary:sundara-lexical:V.12.25</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Suc</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √śuc — цитируется в аппарате на <code>commentary:sundara-lexical:V.12.25</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Шокопахатачетана (śoka-upahata-cetana, adj.) — «тот, чьё сознание (cetana) поражено (upahata) скорбью (śoka)», бахуврихи: śoka «скорбь» (√śuc-, «жечь, скорбеть») + upahata p.p.p. (upa+√han-, «поражать») + cetana «сознание, чувство» (от √cit-, «воспринимать, сознавать»). MW: cetana &#x27;consciousness, understanding&#x27;. Cetana в индийской психологической модели — сознающий, воспринимающий аспект manas (ум</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:cit|commentary:sundara-lexical:V.12.25" data-filt="unique-vs-1058">
+    <header><div class="hw">√cit @ V.12.25 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма śokopahatacetana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:cit|commentary:sundara-lexical:V.12.25</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:cit</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √cit — цитируется в аппарате на <code>commentary:sundara-lexical:V.12.25</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Шокопахатачетана (śoka-upahata-cetana, adj.) — «тот, чьё сознание (cetana) поражено (upahata) скорбью (śoka)», бахуврихи: śoka «скорбь» (√śuc-, «жечь, скорбеть») + upahata p.p.p. (upa+√han-, «поражать») + cetana «сознание, чувство» (от √cit-, «воспринимать, сознавать»). MW: cetana &#x27;consciousness, understanding&#x27;. Cetana в индийской психологической модели — сознающий, воспринимающий аспект manas (ум</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kf|commentary:sundara-lexical:V.13.1" data-filt="unique-vs-1058">
+    <header><div class="hw">√kṛ @ V.13.1 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма prākāra</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kf|commentary:sundara-lexical:V.13.1</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.13.1</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Пракара (prākāra, m.) — «крепостная стена, оборонительная стена города». MW: prākāra &#x27;a surrounding wall or enclosure&#x27;. От pra+√kṛ- «окружать, делать вокруг» или из pra-ākāra «форма-перед». В эпическом описании Lanka упоминаются несколько кольцевых prākāra: это конкретный архитектурный термин дхармашастр и артхашастр (Каутилья) для укреплённого города. Хануман стремителен «словно молния меж туч» —</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:pat|commentary:sundara-lexical:V.13.5" data-filt="unique-vs-1058">
+    <header><div class="hw">√pat @ V.13.5 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма sampāti</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:pat|commentary:sundara-lexical:V.13.5</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:pat</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √pat — цитируется в аппарате на <code>commentary:sundara-lexical:V.13.5</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Сампати (sampāti, m.) — «летящий вместе», имя старейшего грифа-стервятника, брата Джатаю. MW: sampātin &#x27;flying together&#x27;. Sam+pātin (√pat-, «лететь»). Сампати — важный нарративный персонаж Кишкиндхаканды: ослеплённый, он живёт на берегу океана и с высоты своей скалы называет ванарам местонахождение Ситы. Ссылка Ханумана на gṛdhrarājena Sāṃpātinā — «старейшиной грифов Сампати» — единственная внутре</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vA|commentary:sundara-lexical:V.13.7" data-filt="unique-vs-1058">
+    <header><div class="hw">√vā @ V.13.7 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма rāmabāṇa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vA|commentary:sundara-lexical:V.13.7</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vā — цитируется в аппарате на <code>commentary:sundara-lexical:V.13.7</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Рамабана (rāma-bāṇa, m.) — «стрела Рамы», тат-пуруша; в контексте: Равана «боялся стрел Рамы» (bibhyato rāmabāṇānām), поэтому быстро летел. Bāṇa от √vā- («веять») или субстрат не-санскритского происхождения (MW без этимологии). В Рамаяне bāṇa Рамы — конкретные стрелы с сакральными наконечниками (brahmāstra, agneyāstra); их сила — не просто боевая, но и космическая. Страх Раваны перед rāma-bāṇa = с</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:jYA|commentary:sundara-lexical:V.13.28" data-filt="unique-vs-1058">
+    <header><div class="hw">√jñā @ V.13.28 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма kṛtajña</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:jYA|commentary:sundara-lexical:V.13.28</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:jYA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √jñā — цитируется в аппарате на <code>commentary:sundara-lexical:V.13.28</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Критаджна (kṛtajña, adj.) — «знающий [чужие] благодеяния, благодарный», кармадхарайя: kṛta p.p.p. √kṛ- «сделанное, совершённое» + jña «знающий» (√jñā-). MW: kṛtajña &#x27;mindful of former benefits, grateful&#x27;. В дхармашастрах kṛtajñatā — одна из ключевых добродетелей царя (rājadharma): государь должен помнить о тех, кто помог ему в трудную минуту. Сугрива прямо называется kṛtajña в контексте возможной </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kf|commentary:sundara-lexical:V.13.28" data-filt="unique-vs-1058">
+    <header><div class="hw">√kṛ @ V.13.28 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма kṛtajña</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kf|commentary:sundara-lexical:V.13.28</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.13.28</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Критаджна (kṛtajña, adj.) — «знающий [чужие] благодеяния, благодарный», кармадхарайя: kṛta p.p.p. √kṛ- «сделанное, совершённое» + jña «знающий» (√jñā-). MW: kṛtajña &#x27;mindful of former benefits, grateful&#x27;. В дхармашастрах kṛtajñatā — одна из ключевых добродетелей царя (rājadharma): государь должен помнить о тех, кто помог ему в трудную минуту. Сугрива прямо называется kṛtajña в контексте возможной </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:ru|commentary:sundara-lexical:V.13.29" data-filt="unique-vs-1058">
+    <header><div class="hw">√ru @ V.13.29 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма rumā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:ru|commentary:sundara-lexical:V.13.29</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:ru</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ru — цитируется в аппарате на <code>commentary:sundara-lexical:V.13.29</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Рума (rumā, f.) — жена Сугривы, удерживавшаяся Валином в период его царствования. MW: rumā &#x27;N. of the wife of Sugrīva&#x27;. Этимология имени не прозрачна (возможно, от √ru- «реветь» или субстратный апеллятив). В тексте Рума охарактеризована как tapasvinī — «несчастная» (та же лексема, что и Сита в V.13.11), что создаёт внутренний параллелизм двух «несчастных жён»: Ситы и Румы. Подстрочник «добродетель</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:tF|commentary:sundara-lexical:V.13.30" data-filt="unique-vs-1058">
+    <header><div class="hw">√tṝ @ V.13.30 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма tārā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:tF|commentary:sundara-lexical:V.13.30</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:tF</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √tṝ — цитируется в аппарате на <code>commentary:sundara-lexical:V.13.30</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Тара (tārā, f.) — главная жена Валина (Вали), мудрая советница. MW: tārā &#x27;the wife of Bālin (regarded as one of the five very chaste women)&#x27;. Этимология: tārā «звезда» (от √tṝ- «переправляться, спасать»). Тара входит в список pancha-kaṇyā (пяти «девственниц», или великих добродетельных женщин): Ahalyā, Draupadī, Kuntī, Tārā, Mandodarī. MW специально указывает её как «одну из пяти весьма целомудрен</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vas|commentary:sundara-lexical:V.13.56" data-filt="unique-vs-1058">
+    <header><div class="hw">√vas @ V.13.56 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма vasu</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vas|commentary:sundara-lexical:V.13.56</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vas</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vas — цитируется в аппарате на <code>commentary:sundara-lexical:V.13.56</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Васу (vasu, m. pl.) — группа из восьми ведийских богов: Āpa, Dhruva, Soma, Dhara, Anila, Anala, Pratyūṣa, Prabhāsa. MW: vasu &#x27;one of the 8 Vasus (attendants of Indra)&#x27;. Этимология: vasu «хороший, яркий; богатство» (√vas- «сиять», Whitney #612). Хануман перечисляет перед походом в рощу Ашока: Vasu + Rudra + Āditya + Aśvina + Marut = стандартный vedic «каталог богов» (ср. tridaśa в ch11.3 = 33 бога </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:ac|commentary:sundara-lexical:V.14.4" data-filt="unique-vs-1058">
+    <header><div class="hw">√ac @ V.14.4 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма nārāca</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:ac|commentary:sundara-lexical:V.14.4</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:ac</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ac — цитируется в аппарате на <code>commentary:sundara-lexical:V.14.4</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Нарача (nārāca, m.) — «железная стрела», специфически — металлический болт без оперения, более тяжёлый и пронизывающий, чем обычная śara. MW: nārāca &#x27;an iron arrow&#x27;. Этимология неясна; Апте предполагает связь с nāra («вода», воздух?) + √ac- (Apte: nārāca &#x27;a sort of iron arrow&#x27;). В стихе сравнивается движение Ханумана, влетающего в рощу, со стрелой, выпущенной из лука (jyāmukta iva nārācaḥ): образ </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:lI|commentary:sundara-lexical:V.14.52" data-filt="unique-vs-1058">
+    <header><div class="hw">√lī @ V.14.52 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма nilīna</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:lI|commentary:sundara-lexical:V.14.52</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:lI</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √lī — цитируется в аппарате на <code>commentary:sundara-lexical:V.14.52</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Нилина (nilīna, adj.) — «скрытый, затаившийся» (ni+√lī-, «прилипать, таять, прятаться», Whitney #608; MW: nilīna &#x27;hidden, lurking&#x27;). Форма nilīna — p.p. в значении активного состояния: не «спрятанный кем-то», а «сам затаившийся». В 14.52 Хануман nilīna среди листьев и цветов — образ разведчика, растворившегося в пространстве. Глагол √lī- несёт в себе семантику «растворения без следа» (ср. vilīna «</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vas|commentary:sundara-lexical:V.15.19" data-filt="unique-vs-1058">
+    <header><div class="hw">√vas @ V.15.19 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма upavāsa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vas|commentary:sundara-lexical:V.15.19</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vas</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vas — цитируется в аппарате на <code>commentary:sundara-lexical:V.15.19</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Упаваса (upavāsa, m.) — «пост, воздержание от пищи» (upa+√vas-, «сидеть рядом с», в значении «сидеть у [алтаря]»; MW: upavāsa &#x27;fasting as a religious observance&#x27;). Этимология показательна: upavāsa — не просто голодание, а ритуальное сидение возле священного объекта без еды. Сита пребывает в упавасе не по собственному обету, а в силу плена: её вынужденный отказ от пищи автоматически становится риту</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Bf|commentary:sundara-lexical:V.15.41" data-filt="unique-vs-1058">
+    <header><div class="hw">√bhṛ @ V.15.41 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма ābharaṇa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Bf|commentary:sundara-lexical:V.15.41</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Bf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.15.41</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Абхарана (ābharaṇa, n.) — «украшение» (ā+√bhṛ-, «нести», Whitney #148; MW: ābharaṇa &#x27;anything worn as ornament, jewel&#x27;). В 15.41–43 Хануман идентифицирует Ситу именно по ābharaṇa, описанным ему Рамой. Это юридически значимая сцена: украшения — передаваемые из рук в руки семейные ценности, уникальные маркеры личности в дарственных и клятвах. Ābharaṇa здесь функционирует как доказательство (pramāṇa)</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kf|commentary:sundara-lexical:V.15.49" data-filt="unique-vs-1058">
+    <header><div class="hw">√kṛ @ V.15.49 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма kāruṇya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kf|commentary:sundara-lexical:V.15.49</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.15.49</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Карунья (kāruṇya, n.) — «сострадание» (от karuṇa «жалость», √kṛ- или субст. karuṇa + -ya; MW: kāruṇya &#x27;compassion, pity&#x27;). В 15.49–50 четыре чувства Рамы перечислены как: kāruṇya, ānṛśaṃsya («мягкосердечие», отсутствие жестокости), śoka («скорбь»), madana («страсть»). Это — тетрада аффектов, соответствующая базовым расам (karuṇa-rasa, śānta, karuna, śṛṅgāra). Хануман формулирует психологический по</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:sTA|commentary:sundara-lexical:V.15.52" data-filt="unique-vs-1058">
+    <header><div class="hw">√sthā @ V.15.52 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма manas (parasparapratiṣṭhita)</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:sTA|commentary:sundara-lexical:V.15.52</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:sTA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sthā — цитируется в аппарате на <code>commentary:sundara-lexical:V.15.52</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Манас (manas, n.) — «ум, сознание, сердце» (√man-, «думать», Whitney #729; MW: manas &#x27;mind, intellect, intelligence; the seat of feeling and volition&#x27;). В 15.52 сформулирован высший парадокс любви: «asyā manas tasmiṃs tasya cāsyāṃ pratiṣṭhitam» — «её manas пребывает в нём, его — в ней». Pratiṣṭhita (pra+√sthā-, «стоять», «основаться») — архитектурная метафора: manas одного человека = несущая опора</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:so|commentary:sundara-lexical:V.16.4" data-filt="unique-vs-1058">
+    <header><div class="hw">√so @ V.16.4 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма vyavasāya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:so|commentary:sundara-lexical:V.16.4</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:so</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √so — цитируется в аппарате на <code>commentary:sundara-lexical:V.16.4</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Вьявасая (vyavasāya, m.) — «твёрдое решение, непреклонная воля» (vi+ava+√so-, «отрезать, решать», Whitney #993; MW: vyavasāya &#x27;strenuous effort, determination, resolution&#x27;). MW особо отмечает оттенок неотвратимости: vyavasāya — решение, которое уже нельзя отменить, рубикон. В 16.4 Сита «знает vyavasāya Рамы» — это не «намерение», а именно точка невозврата в воле Рамы. Эпитет vyavasāyajñā («знающая</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kal|commentary:sundara-lexical:V.16.14" data-filt="unique-vs-1058">
+    <header><div class="hw">√kal @ V.16.14 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма kalā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kal|commentary:sundara-lexical:V.16.14</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kal</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kal — цитируется в аппарате на <code>commentary:sundara-lexical:V.16.14</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Кала (kalā, f.) — «шестнадцатая доля» (от √kal-, «считать», MW: kalā &#x27;1/16 of anything; a digit of the moon&#x27;). В 16.14 говорится, что власть над тремя мирами «не стоит и kalā Ситы» — не «мизинца» (как иногда переводят), а именно шестнадцатой доли: kalā — наименьшая неделимая мера в системе счисления лунных фаз (moon = 16 kalā; new moon = 1 kalā). Это технический термин квантования ценности: Сита п</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Bf|commentary:sundara-lexical:V.16.19" data-filt="unique-vs-1058">
+    <header><div class="hw">√bhṛ @ V.16.19 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма bhartṛsneha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Bf|commentary:sundara-lexical:V.16.19</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Bf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.16.19</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Бхартрисниха (bhartṛ-sneha, m.) — тат-пуруша: bhartṛ «кормилец, муж» (от √bhṛ-, «нести, кормить», Whitney #148; MW: bhartṛ &#x27;a husband; a master&#x27;) + sneha «маслянистость, липкость → любовь» (√sneh-, MW: sneha &#x27;oiliness; love, affection&#x27;). MW фиксирует sneha как любовь через метафору масла: как масло прилипает, так и привязанность «держит» людей вместе. В 16.19 Сита «влекомая balāt bhartṛsneha» — «с</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:pA|commentary:sundara-lexical:V.16.22" data-filt="unique-vs-1058">
+    <header><div class="hw">√pā @ V.16.22 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма prapā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:pA|commentary:sundara-lexical:V.16.22</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:pA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √pā — цитируется в аппарате на <code>commentary:sundara-lexical:V.16.22</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Прапа (prapā, f.) — «придорожный водоём, цистерна с питьевой водой» (pra+√pā-, «пить», MW: prapā &#x27;a place where water is distributed gratis; a drinking-booth&#x27;). Не просто «источник»: prapā — специфически благотворительный объект, dharmic institution: ставить prapā у дороги в жаркий сезон = обязанность состоятельного человека. В 16.22 Рама ищет Ситу «словно жаждущий ищет prapā» — образ строится на </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:BUz|commentary:sundara-lexical:V.16.26" data-filt="unique-vs-1058">
+    <header><div class="hw">√bhūṣ @ V.16.26 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма bhūṣaṇa (bhartā paraṃ nāryāḥ)</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:BUz|commentary:sundara-lexical:V.16.26</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:BUz</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhūṣ — цитируется в аппарате на <code>commentary:sundara-lexical:V.16.26</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>В 16.26 сформулирован афоризм: «bhartā nāma paraṃ nāryāḥ śobhanaṃ bhūṣaṇād api» — «Воистину муж для женщины — украшение превыше [телесного] украшения». Bhūṣaṇa (n.) — «украшение» (√bhūṣ-, «украшать», MW). Стих строится как силлогизм: Сита «śobhanārhā» («достойная сиять»), но без bhartṛ-bhūṣaṇa не сияет. Bhartṛ здесь осмысляется как метафизическое «украшение»: он придаёт ей статус и свет (śobhā) не</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:hfz|commentary:sundara-lexical:V.17.17" data-filt="unique-vs-1058">
+    <header><div class="hw">√hṛṣ @ V.17.17 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма romaharṣaṇa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:hfz|commentary:sundara-lexical:V.17.17</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:hfz</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √hṛṣ — цитируется в аппарате на <code>commentary:sundara-lexical:V.17.17</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Ромахаршана (roma-harṣaṇa, n./adj.) — «поднимающий волоски» от roma «волос тела» + harṣaṇa «возбуждение, поднятие» (√hṛṣ-, «ощетиниваться, испытывать трепет», Whitney #234). MW: romaharṣa &#x27;bristling of the hair (from fear, cold, or joy)&#x27;. Это стандартный эпический маркер крайнего аффективного состояния — от ужаса и от религиозного восторга одинаково. Здесь применяется к виду ракшаси: их облик вызы</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kzE|commentary:sundara-lexical:V.17.30" data-filt="unique-vs-1058">
+    <header><div class="hw">√kṣai @ V.17.30 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма kṣāma</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kzE|commentary:sundara-lexical:V.17.30</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kzE</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kṣai — цитируется в аппарате на <code>commentary:sundara-lexical:V.17.30</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Кшама (kṣāma, adj.) — «истощённый, иссохший», от √kṣai- / √kṣā- («убывать, истощаться»). MW: kṣāma &#x27;thin, emaciated, weak&#x27;. Апте специально отмечает kṣāma в значении «ослабленный горем или болезнью» в отличие от kṛśa — конституционально «худой». Kṣāma описывает именно ситуативное истощение как результат внешних обстоятельств; здесь оно прямо называет физическое следствие душевного страдания Ситы.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:sraMs|commentary:sundara-lexical:V.18.4" data-filt="unique-vs-1058">
+    <header><div class="hw">√sraṃs @ V.18.4 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма srastamālya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:sraMs|commentary:sundara-lexical:V.18.4</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:sraMs</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sraṃs — цитируется в аппарате на <code>commentary:sundara-lexical:V.18.4</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Срастамалья (srasta-mālya, adj. bahuvr.) — «у кого гирлянды (mālya) соскользнули» (srasta — p.p.p. от √sraṃs-, «падать, соскальзывать», Whitney #706). MW: sraṃs &#x27;to fall down, slip, hang loosely&#x27;. Деталь «соскользнувших гирлянд» — конвенциональный эпический код состояния после ночи с любовницей: герой просыпается с растрёпанными гирляндами, помятой одеждой. Эта формула (srasta-mālya + srasta-āmbar</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vij|commentary:sundara-lexical:V.18.11" data-filt="unique-vs-1058">
+    <header><div class="hw">√vij @ V.18.11 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма vālavyajana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vij|commentary:sundara-lexical:V.18.11</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vij</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vij — цитируется в аппарате на <code>commentary:sundara-lexical:V.18.11</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Валавьяджана (vāla-vyajana, n.) — опахало из хвоста (vāla) яка, коровы или лошади; vāla «хвостовой волос» + vyajana «опахало» (от √vij-, «обмахивать»). MW: vālavyajana &#x27;a fly-flapper or fan made of the hair of a horse or bull&#x27;s tail&#x27;. Царское опахало из ячьих хвостов (cāmara) — строго регламентированный атрибут царской власти в dharmśāstras; число опахал, несомых свитой, указывало на ранг правител</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:DU|commentary:sundara-lexical:V.18.31" data-filt="unique-vs-1058">
+    <header><div class="hw">√dhū @ V.18.31 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма nirdhūta</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:DU|commentary:sundara-lexical:V.18.31</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:DU</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhū — цитируется в аппарате на <code>commentary:sundara-lexical:V.18.31</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Нирдхута (nirdhūta, adj.) — «потрясённый, выбитый из колеи» (ni-+√dhū- «трясти, дрожать», Whitney #181; p.p.p. nirdhūta). MW: nirdhūta &#x27;shaken off, dismissed; shaken&#x27;. Стих 18.31 содержит психологически важную деталь: Хануман — сам сын Ваю, обладатель великой мощи (ugratejāḥ) — был «потрясён» (nirdhūtas) теджасом Раваны. Это не слабость Ханумана, а признание реального могущества Раваны: он — закон</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:jYA|commentary:sundara-lexical:V.19.11" data-filt="unique-vs-1058">
+    <header><div class="hw">√jñā @ V.19.11 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма prajñā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:jYA|commentary:sundara-lexical:V.19.11</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:jYA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √jñā — цитируется в аппарате на <code>commentary:sundara-lexical:V.19.11</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Праджня (prajñā, f.) — «знание, мудрость» (pra+√jñā-, Whitney #660). MW: prajñā &#x27;wisdom, intelligence&#x27;. Стих 19.11 содержит разрушительную четвёрку: «великая слава» (mahākīrti), «вера» (śraddhā), «мудрость» (prajñā), «надежда» (āśā) — все описаны как «утраченные», «попранные», «иссякшие», «отражённые». Эта серия — не просто риторические сравнения, но символические ипостаси самой Ситы: она есть воп</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:luB|commentary:sundara-lexical:V.21.11" data-filt="unique-vs-1058">
+    <header><div class="hw">√lubh @ V.21.11 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма lobha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:luB|commentary:sundara-lexical:V.21.11</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:luB</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √lubh — цитируется в аппарате на <code>commentary:sundara-lexical:V.21.11</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Лобха (lobha, m.) — «жадность, алчность, вожделение», от √lubh- (класс IV, «желать сильно, соблазняться», Whitney #194). MW: lobha &#x27;covetousness, cupidity, greed&#x27;. В этической системе эпоса и брахманических текстов lobha — один из трёх «корневых ядов» (наряду с kāma и moha). В речи Раваны lobha и kāma соседствуют как взаимно различимые мотивы: lobha = стяжательство / жажда обладания, kāma = эротич</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Sap|commentary:sundara-lexical:V.21.24" data-filt="unique-vs-1058">
+    <header><div class="hw">√śap @ V.21.24 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма śāpa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Sap|commentary:sundara-lexical:V.21.24</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Sap</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √śap — цитируется в аппарате на <code>commentary:sundara-lexical:V.21.24</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Шапа (śāpa, m.) — «проклятие, заклятие», от √śap- (класс I/IV, «клясться, проклинать», Whitney #115). MW: śāpa &#x27;a curse, imprecation&#x27;. В эпосе śāpa — конструктивный нарративный элемент: проклятие обладает силой закона и порождает сюжет (Равана проклят несколькими персонажами, в том числе Ведавати). Противоположность — āśīs / āśīrvāda «благословение». Śāpa = перформативный речевой акт: в эпическом </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vf|commentary:sundara-lexical:V.22.33" data-filt="unique-vs-1058">
+    <header><div class="hw">√vṛ @ V.22.33 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма karṇaprāvaraṇā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vf|commentary:sundara-lexical:V.22.33</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.22.33</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Карнаправарана (karṇa-prāvaraṇā, f.) — «покрытая ушами»: karṇa «ухо» + prāvaraṇā «покрывало, оболочка» (pra+√vṛ-, «покрывать»). MW: prāvaraṇa &#x27;a cover, cloak&#x27;. Один из перечисляемых уродливых типов ракшаси: «покрытая ушами» — те, у кого уши столь велики, что служат плащом. Каталог уродств ракшаси (22.33–36) построен на системе нарушений анатомической нормы: количественные (одно ухо/один глаз/одна </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Sru|commentary:sundara-lexical:V.23.7" data-filt="unique-vs-1058">
+    <header><div class="hw">√śru @ V.23.7 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма viśravas</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Sru|commentary:sundara-lexical:V.23.7</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Sru</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √śru — цитируется в аппарате на <code>commentary:sundara-lexical:V.23.7</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Вишравас (viśravas, m.) — «прославленный, известный»: vi- + śravas «слава, слух» (√śru-, «слышать»; ср. греч. κλέος, авест. sravah-). MW: viśravas &#x27;widely renowned; a Ṛishi and father of Kubera and Rāvaṇa&#x27;. Отец как Куберы, так и Раваны (от разных жён). Имя этимологически прозрачно: viśravas = «тот, о ком слышат повсюду (vi = по всему [миру])». Важно: ракшаси намеренно начинают генеалогию с mānasa</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vfz|commentary:sundara-lexical:V.23.17" data-filt="unique-vs-1058">
+    <header><div class="hw">√vṛṣ @ V.23.17 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма puṣpavṛṣṭi</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vfz|commentary:sundara-lexical:V.23.17</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vfz</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vṛṣ — цитируется в аппарате на <code>commentary:sundara-lexical:V.23.17</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Пушпавришти (puṣpa-vṛṣṭi, f.) — «дождь цветов»: puṣpa «цветок, цветение» + vṛṣṭi «дождь» (√vṛṣ-, «лить, орошать»). MW: vṛṣṭi &#x27;rain, a shower&#x27;. Puṣpavṛṣṭi — не только метафора: в эпической и пуранической традиции боги, гандхарвы и само небо «проливают» цветочный дождь как знак божественного одобрения (прежде всего после победы или подвига). Ракшаси описывает, как деревья льют puṣpavṛṣṭi из страха п</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:f|commentary:sundara-lexical:V.23.18" data-filt="unique-vs-1058">
+    <header><div class="hw">√ṛ @ V.23.18 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма nairṛtarāja</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:f|commentary:sundara-lexical:V.23.18</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:f</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.23.18</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Найрритараджа (nairṛta-rāja, m.) — «царь нирритов (ракшасов)»: nairṛta «принадлежащий Нирри́ти» → nairṛta = ракшас (юго-западная сторона света принадлежит Нирри́ти, богине разрушения). MW: nairṛta &#x27;belonging to Nirṛti; a Rākṣasa&#x27;. Nirṛti (ni+√ṛ-, «тот, кто разрушает») — ведийское божество-персонификация распада и несчастья. Ракшасы — её «подданные» по космологии стран света. Этот эпитет для Раваны</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Buj|commentary:sundara-lexical:V.24.4" data-filt="unique-vs-1058">
+    <header><div class="hw">√bhuj @ V.24.4 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма trailokya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Buj|commentary:sundara-lexical:V.24.4</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Buj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhuj — цитируется в аппарате на <code>commentary:sundara-lexical:V.24.4</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Трайлокья (trailokya, n.) — «совокупность трёх миров», стандартная тройная вертикаль индийской космологии: svarga (небо), antarikṣa (воздушное пространство/средний мир) и pṛthivī (земля), или в эпической версии — дэвалока, манушьялока, патала. MW: trailokya &#x27;the 3 Lokas or worlds&#x27;. Равана назван trailokya-vasu-bhoktā — «потребляющим (bhoktā от √bhuj-) богатства (vasu) всей тройной вселенной»: это </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vaD|commentary:sundara-lexical:V.28.5" data-filt="unique-vs-1058">
+    <header><div class="hw">√vadh @ V.28.5 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма vadhyā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vaD|commentary:sundara-lexical:V.28.5</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vaD</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vadh — цитируется в аппарате на <code>commentary:sundara-lexical:V.28.5</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Вадхья (vadhyā, f., adj.) — «подлежащая казни, обречённая на уничтожение» — герундив (критья) от √vadh- «поражать, убивать» (или от √han- в особой форме, MW указывает vadhya как gerundive to vadh/han). MW: vadhya &#x27;to be killed, deserving death; a criminal to be executed&#x27;. Герундив выражает модальное долженствование, а не просто описание: vadhyā — не просто «несчастная», но юридически-ритуально «об</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vid|commentary:sundara-lexical:V.28.17" data-filt="unique-vs-1058">
+    <header><div class="hw">√vid @ V.28.17 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма nirveda</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vid|commentary:sundara-lexical:V.28.17</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vid</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vid — цитируется в аппарате на <code>commentary:sundara-lexical:V.28.17</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Нирведа (nirveda, m.) — «отвращение к миру, уныние, отчаяние»: ni- (интенсивная приставка или «прочь») + veda? Нет — MW выводит от ni+√vid- в значении «пресыщаться, испытывать отвращение» (класс VI ?) или от √nir-vṛd. MW: nirveda &#x27;indifference (to worldly objects), disgust&#x27;. В натьяшастре Бхараты нирведа — один из тридцати трёх вьябхичари-бхав (преходящих эмоциональных состояний, vyabhicāri-bhāva)</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:DI|commentary:sundara-lexical:V.28.20" data-filt="unique-vs-1058">
+    <header><div class="hw">√dhī @ V.28.20 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма dhairya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:DI|commentary:sundara-lexical:V.28.20</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:DI</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhī — цитируется в аппарате на <code>commentary:sundara-lexical:V.28.20</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Дхайрья (dhairya, n.) — «стойкость, невозмутимость, выдержка»: от dhīra adj. «твёрдый, мудрый, невозмутимый» (√dhī- «мысль, разум», Whitney #599 + суфф. -ra) → абстрактный суфф. -ya. MW: dhairya &#x27;firmness, constancy, courage&#x27;. В эпическом и философском контексте dhairya — специфическая добродетель, противопоставленная kātarya «малодушию»: это устойчивость духа, которая не разрушается ни скорбью, н</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:i|commentary:sundara-lexical:V.29.8" data-filt="unique-vs-1058">
+    <header><div class="hw">√i @ V.29.8 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма vītaśoka</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:i|commentary:sundara-lexical:V.29.8</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:i</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √i — цитируется в аппарате на <code>commentary:sundara-lexical:V.29.8</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Вита-шока (vīta-śoka, adj., бахуврихи) — «тот, у кого ушло горе; освободившийся от скорби»: vīta p.p.p. от √vī- (или vi+√i- «идти прочь», Whitney #600) «ушедший, прошедший» + śoka m. «горе» (уже в списке исключённых; здесь в составе нового композита). MW: vīta &#x27;gone away, absent, free from&#x27;. Трансформационная функция слова: предшествующий стих 28.17 зафиксировал nirvedam avāpa («впала в нирведу»),</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vI|commentary:sundara-lexical:V.29.8" data-filt="unique-vs-1058">
+    <header><div class="hw">√vī @ V.29.8 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма vītaśoka</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vI|commentary:sundara-lexical:V.29.8</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vI</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vī — цитируется в аппарате на <code>commentary:sundara-lexical:V.29.8</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Вита-шока (vīta-śoka, adj., бахуврихи) — «тот, у кого ушло горе; освободившийся от скорби»: vīta p.p.p. от √vī- (или vi+√i- «идти прочь», Whitney #600) «ушедший, прошедший» + śoka m. «горе» (уже в списке исключённых; здесь в составе нового композита). MW: vīta &#x27;gone away, absent, free from&#x27;. Трансформационная функция слова: предшествующий стих 28.17 зафиксировал nirvedam avāpa («впала в нирведу»),</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:car|commentary:sundara-lexical:V.30.4" data-filt="unique-vs-1058">
+    <header><div class="hw">√car @ V.30.4 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма cāra</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:car|commentary:sundara-lexical:V.30.4</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:car</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √car — цитируется в аппарате на <code>commentary:sundara-lexical:V.30.4</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Чара (cāra, m.) — «лазутчик, агент разведки»: от √car- (класс I, «двигаться, ходить», Whitney #610) + суфф. -a. MW: cāra m. &#x27;a spy, secret agent; going, motion&#x27;. Арташастра Каутильи выстраивает развёрнутую теорию cāra-системы (кн. I, гл. 11–12): cāra — только один тип разведчика (оперативник в поле), противопоставленный sūtra («нити» агентурной сети) и aṃśa (агентам внедрения). Cāreṇa suyuktena = </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:guh|commentary:sundara-lexical:V.30.4" data-filt="unique-vs-1058">
+    <header><div class="hw">√guh @ V.30.4 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма gūḍha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:guh|commentary:sundara-lexical:V.30.4</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:guh</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √guh — цитируется в аппарате на <code>commentary:sundara-lexical:V.30.4</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Гудха (gūḍha, adj./adv.) — «скрытый, тайный, замаскированный»: p.p.p. от √guh- (класс I, «прятать, скрывать», Whitney #454). MW: gūḍha &#x27;concealed, hidden, secret; not easily understood&#x27;. Семья корня √guh- продуктивна: guha «пещера, тайник» (отсюда Guha «обитатель пещеры» — эпитет Сканды); guhya «тайное, сокровенное» (Бхагавадгита 18.63: sarva-guhyatamaṃ). Хануман caratā gūḍhena = «действуя скрытно</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kf|commentary:sundara-lexical:V.30.17" data-filt="unique-vs-1058">
+    <header><div class="hw">√kṛ @ V.30.17 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма saṃskṛtā vāc</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kf|commentary:sundara-lexical:V.30.17</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.30.17</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Самскрита вач (saṃskṛtā vāc, f.) — «речь, очищенная/упорядоченная» → «санскрит»: saṃskṛta p.p.p. от sam-√kṛ- (sam «со-», √kṛ- «делать», класс VIII, Whitney #890) «приведённая в совершенный порядок, обработанная» + vāc f. «речь» (√vac- «говорить», Whitney #955). MW: saṃskṛta &#x27;refined, adorned, purified; the Sanskrit language&#x27;. Этимология прозрачна, но социолингвистическая значимость — нет: saṃskṛtā</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vac|commentary:sundara-lexical:V.30.17" data-filt="unique-vs-1058">
+    <header><div class="hw">√vac @ V.30.17 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма saṃskṛtā vāc</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vac|commentary:sundara-lexical:V.30.17</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vac</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vac — цитируется в аппарате на <code>commentary:sundara-lexical:V.30.17</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Самскрита вач (saṃskṛtā vāc, f.) — «речь, очищенная/упорядоченная» → «санскрит»: saṃskṛta p.p.p. от sam-√kṛ- (sam «со-», √kṛ- «делать», класс VIII, Whitney #890) «приведённая в совершенный порядок, обработанная» + vāc f. «речь» (√vac- «говорить», Whitney #955). MW: saṃskṛta &#x27;refined, adorned, purified; the Sanskrit language&#x27;. Этимология прозрачна, но социолингвистическая значимость — нет: saṃskṛtā</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:i|commentary:sundara-lexical:V.30.37" data-filt="unique-vs-1058">
+    <header><div class="hw">√i @ V.30.37 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма dūta</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:i|commentary:sundara-lexical:V.30.37</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:i</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √i — цитируется в аппарате на <code>commentary:sundara-lexical:V.30.37</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Дута (dūta, m.) — «посланец, посол»: MW: dūta m. &#x27;a messenger, envoy, ambassador, agent&#x27; — этимология неясна (возможно, √dū- «сжигать»? или от dur-√i-?; MW помечает как &#x27;probably not from √dū&#x27;). В «Артхашастре» Каутильи (I.16) различаются три типа посла: niṣṭha (полномочный, действует по своему усмотрению), parimitākṣara (ограниченный инструкцией) и śāsanahara («несущий грамоту», только курьер). Х</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kf|commentary:sundara-lexical:V.30.41" data-filt="unique-vs-1058">
+    <header><div class="hw">√kṛ @ V.30.41 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма akliṣṭakarman</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kf|commentary:sundara-lexical:V.30.41</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.30.41</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Аклишта-карман (a-kliṣṭa-karman, adj., бахуврихи) — «чьи действия не запятнаны, чьи дела незапятнанны»: a- (отрицание) + kliṣṭa (p.p.p. от √kliś- «страдать, терзаться; пятнать, загрязнять», Whitney #690: kliśnāti/kliśyate) + karman n. «деяние, действие, дело» (от √kṛ-). MW: akliṣṭa &#x27;untroubled, unwearied; undistorted&#x27;; kliṣṭa-karman &#x27;one whose actions are painful/impure&#x27;. Бахуврихи «чьи карманы не</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:BU|commentary:sundara-lexical:V.30.44" data-filt="unique-vs-1058">
+    <header><div class="hw">√bhū @ V.30.44 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма mahānubhāva</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:BU|commentary:sundara-lexical:V.30.44</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:BU</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhū — цитируется в аппарате на <code>commentary:sundara-lexical:V.30.44</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Маханубхава (mahā-anubhāva, adj./m., тат-пуруша) — «великий достоинством, высокий духом»: mahā «великий» + anubhāva m. (anu-√bhū- «следовать за бытием» → «проявление, последствие, сила духа»). MW: anubhāva &#x27;the indication of feeling by gesture and look; dignity, consequence, power of intellect&#x27;. В натьяшастре Бхараты анубхава — технический термин: «последующие индикаторы» (consequents) эмоциональн</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:dF|commentary:sundara-lexical:V.31.3" data-filt="unique-vs-1058">
+    <header><div class="hw">√dṝ @ V.31.3 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма puraṃdara</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:dF|commentary:sundara-lexical:V.31.3</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:dF</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dṝ — цитируется в аппарате на <code>commentary:sundara-lexical:V.31.3</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Пурандара (puraṃ-dara, букв. «разрушитель городов [врагов]») — устойчивый эпитет Индры: puram (акк. мн. от pura «крепость, укреплённый город») + dara от √dṝ- («разрывать, разрушать»). MW: puraṃdara «destroyer of cities or of foes&#x27; strongholds», эпитет Индры. Сравнение Рамы с Пурандарой по воинской силе (bale puraṃdarasamaḥ, 31.3) выбирает военный аспект Индры — разрушителя вражеских цитаделей, а н</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vft|commentary:sundara-lexical:V.31.3" data-filt="unique-vs-1058">
+    <header><div class="hw">√vṛt @ V.31.3 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма cakravartin</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vft|commentary:sundara-lexical:V.31.3</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vft</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vṛt — цитируется в аппарате на <code>commentary:sundara-lexical:V.31.3</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Чакравартин (cakra-vartin, букв. «чьё колесо катится беспрепятственно») — эпический титул вселенского монарха, власть которого символически распространяется на все четыре стороны света. Колесо (cakra) — космический символ суверенной власти и солнечного движения; vartin от √vṛt- (класс I, Whitney #858, «вращаться»). MW: cakravartin «rolling everywhere without obstruction», «world-sovereign». В эпос</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:tap|commentary:sundara-lexical:V.31.7" data-filt="unique-vs-1058">
+    <header><div class="hw">√tap @ V.31.7 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма paraṃtapa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:tap|commentary:sundara-lexical:V.31.7</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:tap</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √tap — цитируется в аппарате на <code>commentary:sundara-lexical:V.31.7</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Парантапа (paraṃ-tapa, букв. «сжигающий врагов») — воинский эпитет: para «чужой, враг» + tapa (от √tap- «жечь, пылать», Whitney #182). MW: paraṃtapa «destroying foes (said of heroes)». Метафора огня в военном словаре восходит к ведийскому образу: победитель обладает теджасом (tejas), буквально «жаром», иссушающим противника. В 31.7 эпитет стоит в одном ряду с rakṣitā («защитник»), образуя полярную</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:DA|commentary:sundara-lexical:V.31.8" data-filt="unique-vs-1058">
+    <header><div class="hw">√dhā @ V.31.8 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма satyābhisaṃdha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:DA|commentary:sundara-lexical:V.31.8</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:DA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhā — цитируется в аппарате на <code>commentary:sundara-lexical:V.31.8</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Сатьябхисандха (satya-abhi-saṃdha, букв. «крепко связанный правдой/обетом») — юридически-этическое понятие: satya «правда» + abhi-saṃdha (от abhi-saṃ-√dhā «скреплять договором, связывать обещанием»). MW: satyābhisaṃdha «true-speaking, faithful to a promise or agreement» (ChUp., R., Car.). Применительно к Дашаратхе (tasya satyābhisaṃdhasya, 31.8) термин прямо формулирует юридическое основание изгна</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:piYj|commentary:sundara-lexical:V.32.1" data-filt="unique-vs-1058">
+    <header><div class="hw">√piñj @ V.32.1 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма piṅgala</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:piYj|commentary:sundara-lexical:V.32.1</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:piYj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √piñj — цитируется в аппарате на <code>commentary:sundara-lexical:V.32.1</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Пингала (piṅgala, adj.) — «рыжевато-бурый, тёмно-золотистый, тёмно-рыжий»: от корня, связанного с piṅga / √piñj «красить в жёлто-красный цвет». MW: piṅgala «reddish-brown, tawny, yellow, gold-coloured» (AV, и далее). В 32.1 vidyutsaṃghātapiṅgalam (букв. «рыжий, как скопление молний») — двойная отсылка: piṅgala — природный цвет обезьян-ванаров (ср. piṅgādhipati «владыка рыжих» = Сугрива), но здесь </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:svap|commentary:sundara-lexical:V.32.3" data-filt="unique-vs-1058">
+    <header><div class="hw">√svap @ V.32.3 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма svapna</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:svap|commentary:sundara-lexical:V.32.3</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:svap</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √svap — цитируется в аппарате на <code>commentary:sundara-lexical:V.32.3</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Свапна (svapna, m.) — «сон (состояние), сновидение»: от √svap- (класс II, Whitney #628, «спать»), с производительным суфф. -na. MW: svapna «sleep, sleeping; a dream». В индийской эпистемологии (ньяя, веданта) svapna — второй из четырёх состояний сознания (avasthā): jāgrat (бодрствование) → svapna (сон со сновидениями) → suṣupti (глубокий сон) → turīya. Сита применяет эту категорию к восприятию Хан</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vac|commentary:sundara-lexical:V.32.14" data-filt="unique-vs-1058">
+    <header><div class="hw">√vac @ V.32.14 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма vācaspati</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vac|commentary:sundara-lexical:V.32.14</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vac</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vac — цитируется в аппарате на <code>commentary:sundara-lexical:V.32.14</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Вачаспати (vācas-pati, букв. «господин/владыка слова») — ведийское имя Брихаспати, жреца и наставника богов: vāc- (от√vac- «говорить», Whitney #245) + pati «господин». MW: vācaspati «lord of speech», N. of Bṛhaspati (RV.). Молитва Ситы (32.14) начинается именно с Вачаспати-Брихаспати, «вооружённого ваджрой» (savajriṇe) — нестандартная эпитетология: ваджра — оружие Индры, но Брихаспати как военный </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:ruh|commentary:sundara-lexical:V.33.7" data-filt="unique-vs-1058">
+    <header><div class="hw">√ruh @ V.33.7 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма rohiṇī</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:ruh|commentary:sundara-lexical:V.33.7</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:ruh</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ruh — цитируется в аппарате на <code>commentary:sundara-lexical:V.33.7</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Рохини (rohiṇī) — в астральном регистре: главная жена Луны (Чандры), букв. «красноватая» (от √ruh- «расти, подниматься», суфф. -iṇī с цветовым значением). MW: rohiṇī «the most propitious of the lunar mansions (described as a red star, the 4th of the 27 or 28 nakshatras, identified with Aldebaran in Taurus)». Рохини — любимая накшатра Чандры; остальные 27 жён ревнуют. В 33.7 Hanuman сравнивает Ситу</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:dA|commentary:sundara-lexical:V.33.22" data-filt="unique-vs-1058">
+    <header><div class="hw">√dā @ V.33.22 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма varadāna</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:dA|commentary:sundara-lexical:V.33.22</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:dA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dā — цитируется в аппарате на <code>commentary:sundara-lexical:V.33.22</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Варадана (vara-dāna, n.) — «дарование бона, исполнение просьбы»: vara (MW: «a boon, wish, blessing granted by a deity») + dāna (от √dā- «давать»). MW: varadāna «the granting a boon or request» (MBh., R.). В 33.22 daśaratha «вспомнил varadāna» (varadānam anusmaran) — это ключевой юридический термин: var-обет, данный Кайкейи, имеет силу сакрального договора (ср. satyābhisaṃdha, 31.8). Пара satyābhis</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:car|commentary:sundara-lexical:V.35.12" data-filt="unique-vs-1058">
+    <header><div class="hw">√car @ V.35.12 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма brahmacaryavrata</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:car|commentary:sundara-lexical:V.35.12</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:car</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √car — цитируется в аппарате на <code>commentary:sundara-lexical:V.35.12</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Брахмачарьяврата (brahma-carya-vrata, n.) — «обет брахмачарьи», тройной тат-пуруша: brahman + carya (поведение, образ жизни, √car-) + vrata (обет). Brahmacarya в буквальном смысле — «хождение в Брахмане», т.е. жизнь в соответствии с высшей реальностью; в дхармашастрах это первый ашрам (студент), обязательно включающий целибат. MW: brahmacarya «study of the Vedas; religious studentship; continence»</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:BA|commentary:sundara-lexical:V.35.37" data-filt="unique-vs-1058">
+    <header><div class="hw">√bhā @ V.35.37 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма niṣprabha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:BA|commentary:sundara-lexical:V.35.37</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:BA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhā — цитируется в аппарате на <code>commentary:sundara-lexical:V.35.37</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Нишпрабха (niṣ-prabha, adj.) — «лишённый блеска/сияния», бахуврихи: niṣ- (лишение) + prabha «блеск, сияние» (√bhā- «светить»). MW: niṣprabha «without lustre, dim». Сравнение: Сугрива, услышав о похищении Ситы, стал niṣprabha «как солнце, схваченное планетой» (grahagrasta ivāṃśumān). Prabha — не просто «яркость», а жизненная сила, проявляющаяся в блеске лица и тела. Утрата prabha = видимый знак душ</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:i|commentary:sundara-lexical:V.35.58" data-filt="unique-vs-1058">
+    <header><div class="hw">√i @ V.35.58 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма śokaparīta</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:i|commentary:sundara-lexical:V.35.58</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:i</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √i — цитируется в аппарате на <code>commentary:sundara-lexical:V.35.58</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Шокапарита (śoka-parīta, adj.) — «охваченный горем», бахуврихи: śoka + parīta (p.p.p. от pari+√i- «окружать, охватывать»). MW: parīta «surrounded, encompassed». Корень √i- («идти») в сочетании с pari- даёт образ «обхождения вокруг» — горе окружает человека со всех сторон, как кольцо. В отличие от paripluta (V.11.16 — «затопленный», образ из воды) и śokāgni (огонь), parīta — образ осады, окружения.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:pat|commentary:sundara-lexical:V.35.64" data-filt="unique-vs-1058">
+    <header><div class="hw">√pat @ V.35.64 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма saṃpāti</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:pat|commentary:sundara-lexical:V.35.64</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:pat</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √pat — цитируется в аппарате на <code>commentary:sundara-lexical:V.35.64</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Сампати (saṃpāti, m.) — царь стервятников, старший брат Джатаю. Этимология: sam+pāti (от √pat- «лететь», «летящий вместе»). В данном эпизоде Сампати появляется как «спасительный вестник»: он знает, где находится Сита (видел с небес). Важная деталь: Сампати когда-то потерял крылья, защищая Джатаю от солнечного жара. Его появление здесь — не случайное: это брат того, кто погиб, защищая Ситу. Информа</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:DU|commentary:sundara-lexical:V.35.72" data-filt="unique-vs-1058">
+    <header><div class="hw">√dhū @ V.35.72 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма vyavadhūya bhaya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:DU|commentary:sundara-lexical:V.35.72</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:DU</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhū — цитируется в аппарате на <code>commentary:sundara-lexical:V.35.72</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Вьявадхуя бхая (vyavadhūya bhaya, ger.+n.) — «отряхнув страх», от vi+ava+√dhū- («трясти, стряхивать»). MW: vyavadhūta «shaken off, repelled». Образ физический: страх — нечто прилипшее, что можно стряхнуть с тела. Глагол √dhū- используется для отряхивания воды, пыли, грязи с одежды или тела. Hanuman «отряхивает» страх как пыль — это образ полного и физически ощутимого избавления от страха. Важная п</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:BU|commentary:sundara-lexical:V.35.90" data-filt="unique-vs-1058">
+    <header><div class="hw">√bhū @ V.35.90 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма vāyuprabhava</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:BU|commentary:sundara-lexical:V.35.90</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:BU</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhū — цитируется в аппарате на <code>commentary:sundara-lexical:V.35.90</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Ваюпрабхава (vāyu-prabhava, adj.) — «происходящий от Ваю», тат-пуруша: vāyu «ветер» + prabhava «происхождение, источник» (pra+√bhū-). MW: prabhava «origin, coming forth». В последнем стихе главы Хануман подтверждает Сите своё происхождение: vāyuprabhavo hi maithili. Это не просто биографическая справка — это объяснение его сверхспособностей: скорость, сила, способность летать через океан происходя</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:uc|commentary:sundara-lexical:V.36.21" data-filt="unique-vs-1058">
+    <header><div class="hw">√uc @ V.36.21 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма sukha-anūcita / duḥkha-anūcita</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:uc|commentary:sundara-lexical:V.36.21</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:uc</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √uc — цитируется в аппарате на <code>commentary:sundara-lexical:V.36.21</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Сукха-анучита / духкха-анучита (sukha-anūcita / duḥkha-anūcita, adj.) — «привыкший к счастью / непривыкший к несчастью», бахуврихи: sukha/duḥkha + anūcita (an- + ūcita, p.p.p. от √uc- «быть привычным»). MW: ucita «accustomed to, fit, proper». Сита формулирует парадокс: Рама «всегда привычен к счастью» (sukhasya uccitaḥ) и «не привычен к несчастью» (duḥkhasya anūcitaḥ) — и теперь должен переносить </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:hi|commentary:sundara-lexical:V.36.28" data-filt="unique-vs-1058">
+    <header><div class="hw">√hi @ V.36.28 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма hemasamānavarṇa ānana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:hi|commentary:sundara-lexical:V.36.28</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:hi</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √hi — цитируется в аппарате на <code>commentary:sundara-lexical:V.36.28</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Хемасаманаварна-анана (hema-samāna-varṇa ānana, n.) — «лицо, цветом равное золоту». Hema «золото» (&lt; √hi- «бросать», т.е. «метаемое», ценность); samāna «равный»; varṇa «цвет, масть»; ānana «лицо». Сита описывает лицо Рамы через тройное сравнение: золото + padma (лотос, сравнение через запах: padmasamānagandhi) = «лицо лотоса с запахом и цвета золота». Золотой цвет лица — эпический признак сакральн</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:DyE|commentary:sundara-lexical:V.36.43" data-filt="unique-vs-1058">
+    <header><div class="hw">√dhyai @ V.36.43 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма dhyānapara</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:DyE|commentary:sundara-lexical:V.36.43</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:DyE</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhyai — цитируется в аппарате на <code>commentary:sundara-lexical:V.36.43</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Дхьянапара (dhyāna-para, adj.) — «поглощённый медитацией», бахуврихи: dhyāna «сосредоточенная медитация» (от √dhyai- «думать, созерцать») + para «высший, погружённый в». MW: dhyāna «meditation, thought, reflection; (in yoga) profound and abstract religious meditation». Para здесь — не просто «занятый», а «полностью отдавшийся»: dhyāna-para = тот, для кого dhyāna стало высшим (para). Рама описан ка</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:DA|commentary:sundara-lexical:V.37.4" data-filt="unique-vs-1058">
+    <header><div class="hw">√dhā @ V.37.4 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма vidhi</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:DA|commentary:sundara-lexical:V.37.4</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:DA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhā — цитируется в аппарате на <code>commentary:sundara-lexical:V.37.4</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Видхи (vidhi, m., √dhā- «устанавливать», vi-√dhā) — «установление, предписание, судьба». MW: vidhi m. &#x27;rule, precept; fate, destiny&#x27;. Отличие от kṛtānta: vidhi — безличная норма, тогда как kṛtānta — действующий деятель. Сита использует оба термина в соседних стихах, нарастающий образ тотальной несвободы.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:dA|commentary:sundara-lexical:V.37.10" data-filt="unique-vs-1058">
+    <header><div class="hw">√dā @ V.37.10 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма pratipradāna</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:dA|commentary:sundara-lexical:V.37.10</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:dA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dā — цитируется в аппарате на <code>commentary:sundara-lexical:V.37.10</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Прати-прадана (prati-pra-dāna, n.) — «возвращение, отдача обратно» (prati «обратно» + pra-√dā «давать»). MW: pratidāna n. &#x27;a return gift; restoring&#x27;. Юридический термин: pratipradāna — «выдача обратно» — используется в контексте спора/выкупа. Равана «не хочет возвращать» — формульное нарушение dharmic обязательства обмена.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kf|commentary:sundara-lexical:V.37.18" data-filt="unique-vs-1058">
+    <header><div class="hw">√kṛ @ V.37.18 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма divākara</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kf|commentary:sundara-lexical:V.37.18</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.37.18</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Дивакара (divā-kara, m.) — «делающий день» (divā «днём» + kara «делатель», √kṛ-) = эпитет Солнца. MW: divākara m. &#x27;the sun&#x27;. Рама как divākara — многозначная метафора: (1) солнце сушит воду («врагов-ракшасов» = rakṣo-maya-toya); (2) солнце рассеивает тьму; (3) солнце одно, незаменимо. Стрелы Рамы = лучи (śara-jāla-aṃśu). Развёрнутое солярное уподобление.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:su|commentary:sundara-lexical:V.38.11" data-filt="unique-vs-1058">
+    <header><div class="hw">√su @ V.38.11 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма surasutā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:su|commentary:sundara-lexical:V.38.11</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:su</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √su — цитируется в аппарате на <code>commentary:sundara-lexical:V.38.11</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Сурасута (sura-sutā, f.) — «дочь бога» (sura «бог» + sutā «дочь», от √su- «рождать»). MW: sura m. &#x27;a god, divinity&#x27;. Сита уподобляется surasutā: подобно тому, как дочь богов небесна по природе, так Сита — небесного происхождения (она найдена в борозде, т.е. рождена землёй; но в образной системе эпоса — apsaras-quality).</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:IS|commentary:sundara-lexical:V.38.55" data-filt="unique-vs-1058">
+    <header><div class="hw">√īś @ V.38.55 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма aiśvarya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:IS|commentary:sundara-lexical:V.38.55</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:IS</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √īś — цитируется в аппарате на <code>commentary:sundara-lexical:V.38.55</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Айшварья (aiśvarya, n.) — «владычество, верховная власть» (от īśvara «владыка, господь» + ya; īśvara = √īś- «властвовать»). MW: aiśvarya n. &#x27;dominion, sovereignty; the state of being the lord God&#x27;. Сита перечисляет то, что осталось у Рамы на земле: aiśvarya как политическая власть / dharmic dominion. В Sāṃkhya / Vedānta aiśvarya — одна из восьми сверхсил (aiśvarya, bala, vīrya, etc.).</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:sev|commentary:sundara-lexical:V.38.59" data-filt="unique-vs-1058">
+    <header><div class="hw">√sev @ V.38.59 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма vṛddhopasevī</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:sev|commentary:sundara-lexical:V.38.59</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:sev</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sev — цитируется в аппарате на <code>commentary:sundara-lexical:V.38.59</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Врудхопасевин (vṛddha-upasevī, m.) — «служащий старшим» (vṛddha «пожилой, старший» + upasevī «служитель», upa-√sev- «служить, почитать»). MW: upasevā f. &#x27;attendance upon, service, worship&#x27;. Эпитет Лакшманы подчёркивает одно из главных качеств kṣatriya-сына: служение старшим — dharmic обязательство, а не просто деликатность.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:pat|commentary:sundara-lexical:V.38.65" data-filt="unique-vs-1058">
+    <header><div class="hw">√pat @ V.38.65 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма pātāla</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:pat|commentary:sundara-lexical:V.38.65</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:pat</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √pat — цитируется в аппарате на <code>commentary:sundara-lexical:V.38.65</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Патала (pātāla, n.) — «подземный мир» (от √pat- «падать» + āla «вместилище»; MW не решает этимологию окончательно). MW: pātāla n. &#x27;the underworld, one of the seven regions under the earth&#x27;. «Спаси меня как Каушики из Паталы»: аллюзия на миф о Вишвамитре (Каушики = «сын Кушики»), связанном в подземном мире. Без этого мифологического пресуппозита сравнение не имеет смысла.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:sah|commentary:sundara-lexical:V.39.3" data-filt="unique-vs-1058">
+    <header><div class="hw">√sah @ V.39.3 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма samutsāha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:sah|commentary:sundara-lexical:V.39.3</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:sah</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sah — цитируется в аппарате на <code>commentary:sundara-lexical:V.39.3</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Самутсаха (samutsāha, m.) — «полная/совместная решимость» (sam-ut-√sah- «выносить, терпеть»). MW: utsāha m. &#x27;energy, resolution, perseverance&#x27;. sam + ut- усиливают √sah-: получается «возросшая до предела энергия». Сита буквально говорит: «ты, вновь побуждённый samutsāhena» — т.е. она признаёт, что его энергия нуждается в новом импульсе после разочарования от её отказа.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:aYj|commentary:sundara-lexical:V.39.6" data-filt="unique-vs-1058">
+    <header><div class="hw">√añj @ V.39.6 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма añjali</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:aYj|commentary:sundara-lexical:V.39.6</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:aYj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √añj — цитируется в аппарате на <code>commentary:sundara-lexical:V.39.6</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Анджали (añjali, m.) — «сложенные ладони» (от √añj- «умащать, украшать»): жест приветствия и почтения. MW: añjali m. &#x27;the open hands placed side by side and slightly hollowed&#x27;. añjali-karma — ритуальный жест; здесь śirasy añjalim ādhāya = «положив анджали на голову» = наивысшая степень уважения (añjali at level of heart = обычное; at forehead = высокое; at head = высшее).</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:ruD|commentary:sundara-lexical:V.39.9" data-filt="unique-vs-1058">
+    <header><div class="hw">√rudh @ V.39.9 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма duḥkhāmbu</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:ruD|commentary:sundara-lexical:V.39.9</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:ruD</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √rudh — цитируется в аппарате на <code>commentary:sundara-lexical:V.39.9</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Дукхамбу (duḥkha-ambu, n.) — «вода несчастья» (duḥkha «несчастье» + ambu «вода»): в составе duḥkhāmbusaṃrodha «заграждение воды несчастья» (saṃrodha, sam-√rudh-). MW: ambu n. &#x27;water&#x27;; saṃrodha m. &#x27;obstruction, confinement&#x27;. Метафора «несчастье = вода в запруде»: Сита заперта в океане/запруде горя; tārayati (освободит) = прорвёт запруду.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Suc|commentary:sundara-lexical:V.40.24" data-filt="unique-vs-1058">
+    <header><div class="hw">√śuc @ V.40.24 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма śokavega</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Suc|commentary:sundara-lexical:V.40.24</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Suc</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √śuc — цитируется в аппарате на <code>commentary:sundara-lexical:V.40.24</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Шокавега (śoka-vega, m.) — тат-пуруша: śoka m. «скорбь, горе» (√śuc-, «скорбеть, пылать», класс I, Whitney #254) + vega m. «скорость, стремительный поток, порыв» (√vij-, «устремляться», или √veg-). MW: vega &#x27;a stream, current; speed, velocity; onset, attack; agitation of mind&#x27;. Vega — физический термин древнеиндийской натурфилософии (Nyāya-Vaiśeṣika): одно из guṇa-s, обозначающее кинетическую силу</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vij|commentary:sundara-lexical:V.40.24" data-filt="unique-vs-1058">
+    <header><div class="hw">√vij @ V.40.24 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма śokavega</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vij|commentary:sundara-lexical:V.40.24</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vij</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vij — цитируется в аппарате на <code>commentary:sundara-lexical:V.40.24</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Шокавега (śoka-vega, m.) — тат-пуруша: śoka m. «скорбь, горе» (√śuc-, «скорбеть, пылать», класс I, Whitney #254) + vega m. «скорость, стремительный поток, порыв» (√vij-, «устремляться», или √veg-). MW: vega &#x27;a stream, current; speed, velocity; onset, attack; agitation of mind&#x27;. Vega — физический термин древнеиндийской натурфилософии (Nyāya-Vaiśeṣika): одно из guṇa-s, обозначающее кинетическую силу</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:hu|commentary:sundara-lexical:V.42.22" data-filt="unique-vs-1058">
+    <header><div class="hw">√hu @ V.42.22 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма hutāgni</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:hu|commentary:sundara-lexical:V.42.22</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:hu</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √hu — цитируется в аппарате на <code>commentary:sundara-lexical:V.42.22</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Хутагни (huta-agni, m.) — тат-пуруша: huta p.p.p. от √hu- (класс III, «жертвовать, лить в огонь», Whitney #660) + agni m. «огонь». MW: huta &#x27;sacrificed, offered in fire; p.p. of √hu&#x27;; hutāśana &#x27;eating offerings, fire&#x27;. Hutāgni — не просто «огонь», а жертвенный огонь, питаемый возлияниями (āhuti): он горит ярче и интенсивнее обычного. MW: hutāgni implicitly = sacred fire fed by oblation. Равана «вс</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:ji|commentary:sundara-lexical:V.42.33" data-filt="unique-vs-1058">
+    <header><div class="hw">√ji @ V.42.33 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма jayati (jayaśabda)</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:ji|commentary:sundara-lexical:V.42.33</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:ji</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ji — цитируется в аппарате на <code>commentary:sundara-lexical:V.42.33</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>«Джаяти» (√ji-, «побеждать», 3sg. praes. act., класс I, Whitney #612) в контексте V.42.33–34 — не описание факта, а боевой клич-провозглашение (jayaśabda). MW: jaya &#x27;conquering, winning; victory, triumph&#x27;; jayati &#x27;(he) conquers&#x27;. Формула «jayaty atibalo rāmo lakṣmaṇaś ca mahābalaḥ / rājā jayati sugrīvo rāghaveṇābhipālitaḥ» — тройное провозглашение победы в сердце вражеской крепости. Это аналог вед</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:as|commentary:sundara-lexical:V.43.8" data-filt="unique-vs-1058">
+    <header><div class="hw">√as @ V.43.8 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма astravij</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:as|commentary:sundara-lexical:V.43.8</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:as</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √as — цитируется в аппарате на <code>commentary:sundara-lexical:V.43.8</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Астравидж (astra-vij / astra-vid, adj./m.) — «знающий оружие», от astra (n., «метательное оружие, боевое заклинание», √as- «метать», Whitney #155) + vid («знающий», √vid- «знать»). MW: astravid &#x27;skilled in missiles&#x27;. Ключевое отличие от dhanurdhar («держащий лук»): astravid — владение оружием мистическим, формульным (astravidyā); такой воин поражает оружием «словесно», то есть владеет заклинательн</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vid|commentary:sundara-lexical:V.43.8" data-filt="unique-vs-1058">
+    <header><div class="hw">√vid @ V.43.8 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма astravij</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vid|commentary:sundara-lexical:V.43.8</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vid</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vid — цитируется в аппарате на <code>commentary:sundara-lexical:V.43.8</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Астравидж (astra-vij / astra-vid, adj./m.) — «знающий оружие», от astra (n., «метательное оружие, боевое заклинание», √as- «метать», Whitney #155) + vid («знающий», √vid- «знать»). MW: astravid &#x27;skilled in missiles&#x27;. Ключевое отличие от dhanurdhar («держащий лук»): astravid — владение оружием мистическим, формульным (astravidyā); такой воин поражает оружием «словесно», то есть владеет заклинательн</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:f|commentary:sundara-lexical:V.44.2" data-filt="unique-vs-1058">
+    <header><div class="hw">√ṛ @ V.44.2 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма samaradurjaya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:f|commentary:sundara-lexical:V.44.2</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:f</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.44.2</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Самарадурджая (samara-durjaya, adj.) — тат-пуруша: samara «битва» (от sam-√ṛ- «сходиться», √ṛ- «идти», Whitney #24) + dur- (отрицательный префикс «трудно») + jaya (√ji- «побеждать»). MW: samara &#x27;conflict, battle&#x27;; durjaya &#x27;hard to be conquered&#x27;. Стандартный перевод «труднопобедимый в бою» не раскрывает, что samara — именно «схождение, столкновение» (не yuddha «борьба» и не raṇa «поле»). Samara под</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:ji|commentary:sundara-lexical:V.44.2" data-filt="unique-vs-1058">
+    <header><div class="hw">√ji @ V.44.2 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма samaradurjaya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:ji|commentary:sundara-lexical:V.44.2</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:ji</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ji — цитируется в аппарате на <code>commentary:sundara-lexical:V.44.2</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Самарадурджая (samara-durjaya, adj.) — тат-пуруша: samara «битва» (от sam-√ṛ- «сходиться», √ṛ- «идти», Whitney #24) + dur- (отрицательный префикс «трудно») + jaya (√ji- «побеждать»). MW: samara &#x27;conflict, battle&#x27;; durjaya &#x27;hard to be conquered&#x27;. Стандартный перевод «труднопобедимый в бою» не раскрывает, что samara — именно «схождение, столкновение» (не yuddha «борьба» и не raṇa «поле»). Samara под</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:cal|commentary:sundara-lexical:V.46.17" data-filt="unique-vs-1058">
+    <header><div class="hw">√cal @ V.46.17 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма yuddhasiddhi</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:cal|commentary:sundara-lexical:V.46.17</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:cal</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √cal — цитируется в аппарате на <code>commentary:sundara-lexical:V.46.17</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Юддха-сиддхи (yuddha-siddhi, f.) — тат-пуруша: yuddha «битва» (√yudh-, «сражаться», Whitney #239) + siddhi «успех, достижение, совершенство» (√sidh-, «преуспевать»). MW: yuddhasiddhi &#x27;success in war&#x27;. Равана характеризует yuddhasiddhi как cañcala — «непостоянную» (от √cal-, «колебаться»). Это редкий момент, где демонический царь демонстрирует понимание принципа кшатрийской этики: военная удача по </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:siD|commentary:sundara-lexical:V.46.17" data-filt="unique-vs-1058">
+    <header><div class="hw">√sidh @ V.46.17 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма yuddhasiddhi</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:siD|commentary:sundara-lexical:V.46.17</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:siD</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sidh — цитируется в аппарате на <code>commentary:sundara-lexical:V.46.17</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Юддха-сиддхи (yuddha-siddhi, f.) — тат-пуруша: yuddha «битва» (√yudh-, «сражаться», Whitney #239) + siddhi «успех, достижение, совершенство» (√sidh-, «преуспевать»). MW: yuddhasiddhi &#x27;success in war&#x27;. Равана характеризует yuddhasiddhi как cañcala — «непостоянную» (от √cal-, «колебаться»). Это редкий момент, где демонический царь демонстрирует понимание принципа кшатрийской этики: военная удача по </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:yuD|commentary:sundara-lexical:V.46.17" data-filt="unique-vs-1058">
+    <header><div class="hw">√yudh @ V.46.17 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма yuddhasiddhi</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:yuD|commentary:sundara-lexical:V.46.17</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:yuD</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √yudh — цитируется в аппарате на <code>commentary:sundara-lexical:V.46.17</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Юддха-сиддхи (yuddha-siddhi, f.) — тат-пуруша: yuddha «битва» (√yudh-, «сражаться», Whitney #239) + siddhi «успех, достижение, совершенство» (√sidh-, «преуспевать»). MW: yuddhasiddhi &#x27;success in war&#x27;. Равана характеризует yuddhasiddhi как cañcala — «непостоянную» (от √cal-, «колебаться»). Это редкий момент, где демонический царь демонстрирует понимание принципа кшатрийской этики: военная удача по </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:grah|commentary:sundara-lexical:V.47.4" data-filt="unique-vs-1058">
+    <header><div class="hw">√grah @ V.47.4 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма tapaḥsaṃgraha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:grah|commentary:sundara-lexical:V.47.4</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:grah</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √grah — цитируется в аппарате на <code>commentary:sundara-lexical:V.47.4</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Тапах-санграха (tapaḥ-saṃgraha, m.) — тат-пуруша: tapas «аскеза» + saṃgraha «совокупность, накопление» (sam+√grah-, «собирать», Whitney #706). MW: saṃgraha &#x27;collection, accumulation&#x27;. Колесница Акши arjita tapaḥsaṃgrahasaṃcayena — «обретённая накоплением совокупного результата аскезы» — несёт ключевую идею: это не просто военное снаряжение, а материализованный кармический капитал. В индийской трад</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:rAD|commentary:sundara-lexical:V.48.2" data-filt="unique-vs-1058">
+    <header><div class="hw">√rādh @ V.48.2 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма pitāmahārādhana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:rAD|commentary:sundara-lexical:V.48.2</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:rAD</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √rādh — цитируется в аппарате на <code>commentary:sundara-lexical:V.48.2</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Питамаха-арадхана (pitāmaha-ārādhana, n.) — тат-пуруша: pitāmaha «дед, прадед; Брахма» (pitā «отец» + maha «великий»; MW: pitāmaha &#x27;grandfather, Brahma&#x27;) + ārādhana «умилостивление, почитание» (ā+√rādh-, «завершить, умилостивить»). Индраджит pitāmahārādhanasaṃcitāstraḥ — «обладающий оружием, накопленным умилостивлением Брахмы». Ключевая концепция: astra (небесное оружие) — не просто техническое ср</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:DA|commentary:sundara-lexical:V.48.4" data-filt="unique-vs-1058">
+    <header><div class="hw">√dhā @ V.48.4 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма deśakālapradhāna</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:DA|commentary:sundara-lexical:V.48.4</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:DA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhā — цитируется в аппарате на <code>commentary:sundara-lexical:V.48.4</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Дешакала-прадхана (deśa-kāla-pradhāna, adj.) — тат-пуруша: deśa «место» + kāla «время» + pradhāna «первенствующий, главный» (pra+√dhā-, «ставить первым»). MW: pradhāna &#x27;principal, chief, pre-eminent&#x27;. Равана описывает Индраджита как deśakālapradhāna — того, кто главенствует в использовании места и времени. Это та же пара deśa-kāla из V.46.5, но выраженная через превосходство: не просто «следующий </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Df|commentary:sundara-lexical:V.48.13" data-filt="unique-vs-1058">
+    <header><div class="hw">√dhṛ @ V.48.13 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма rājadharma</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Df|commentary:sundara-lexical:V.48.13</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Df</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.48.13</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Раджа-дхарма (rāja-dharma, m.) — тат-пуруша: rāja «царь» + dharma «закон, долг, порядок» (√dhṛ-, «держать, поддерживать», Whitney #804). MW: rājadharma &#x27;the duty or law of kings&#x27;. Rājadharma — специализированный раздел дхармашастры (XII Книга Махабхараты, Шантипарва, целиком ему посвящена). Равана, посылая Индраджита и оговаривая, что это «не лучшая мысль» (na matirśreṣṭha), апеллирует к rājadharm</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:dfS|commentary:sundara-lexical:V.48.44" data-filt="unique-vs-1058">
+    <header><div class="hw">√dṛś @ V.48.44 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма guṇadarśana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:dfS|commentary:sundara-lexical:V.48.44</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:dfS</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dṛś — цитируется в аппарате на <code>commentary:sundara-lexical:V.48.44</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Гуна-даршана (guṇa-darśana, n.) — тат-пуруша: guṇa «качество, достоинство, польза» + darśana «видение, перспектива» (√dṛś-, «видеть», Whitney #382). MW: guṇa &#x27;quality, virtue, merit; advantage&#x27;; darśana &#x27;seeing; view, system of thought&#x27;. Хануман рассуждает: grahaṇe cāpi rakṣobhir mahan me guṇadarśanam — «и в плении ракшасами я вижу великую выгоду (guṇa)». Guṇadarśana — способность увидеть скрытый </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:as|commentary:sundara-lexical:V.48.48" data-filt="unique-vs-1058">
+    <header><div class="hw">√as @ V.48.48 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма astrabandha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:as|commentary:sundara-lexical:V.48.48</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:as</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √as — цитируется в аппарате на <code>commentary:sundara-lexical:V.48.48</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Астра-бандха (astra-bandha, m.) — тат-пуруша: astra «метаемое оружие, оружие богов» (√as-, «метать», Whitney #155) + bandha «связь, оковы» (√bandh-, «вязать», Whitney #691). MW: astra &#x27;a missile weapon, supernatural weapon&#x27;; bandha &#x27;binding, bond&#x27;. Astrabandha — юридически-ритуальный термин эпической оружейной этики: оковы, наложенные astram, несовместимы с физическими верёвками (valkena baddhaḥ =</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:yuj|commentary:sundara-lexical:V.49.3" data-filt="unique-vs-1058">
+    <header><div class="hw">√yuj @ V.49.3 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма vajrasaṃyoga</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:yuj|commentary:sundara-lexical:V.49.3</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:yuj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √yuj — цитируется в аппарате на <code>commentary:sundara-lexical:V.49.3</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Ваджрасамйога (vajra-saṃyoga, m.) — тат-пуруша: vajra «ваджра, молния/бриллиант» + saṃyoga «соединение, инкрустация» (√yuj- + sam-). MW: vajra &#x27;(lit.) the hard or mighty one; a thunderbolt; a diamond&#x27;. В ювелирном контексте vajra = алмаз (bhadrasāra); vajrasaṃyoga = «инкрустированный алмазами». Украшения Раваны «соединены с ваджрой» — то есть усеяны бриллиантами. Переводчик вынужден выбирать между</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:tij|commentary:sundara-lexical:V.50.8" data-filt="unique-vs-1058">
+    <header><div class="hw">√tij @ V.50.8 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма teja</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:tij|commentary:sundara-lexical:V.50.8</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:tij</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √tij — цитируется в аппарате на <code>commentary:sundara-lexical:V.50.8</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Теджас (tejas, n.) — «огненная энергия, блеск, мощь»; от √tij- / корень tej- («быть острым, пылать»). MW: tejas &#x27;sharpness, the sharp edge (of a knife etc.); heat, glow; fire; vital power, energy, spirit&#x27;. Теджас — центральная категория эпической антропологии: накапливается через тапас, передаётся взглядом, излучается телом. Ханумана «окружённого теджасом» (tejasā vṛtam) Равана видит физически — т</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Buj|commentary:sundara-lexical:V.51.20" data-filt="unique-vs-1058">
+    <header><div class="hw">√bhuj @ V.51.20 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма bhujaga</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Buj|commentary:sundara-lexical:V.51.20</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Buj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhuj — цитируется в аппарате на <code>commentary:sundara-lexical:V.51.20</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Бхуджага (bhujaga, m.) — «змея, ползущая на изгибах»; народная этимология: bhuja «рука/изгиб» (от √bhuj-, «гнуть») + ga «идущий» (от √gam-). MW: bhujaga &#x27;a serpent (lit. going in curves)&#x27;. Поэтический термин для змеи, акцентирующий способ передвижения через скручивание. Рама сравнивается: «Как Гаруда для змей — Рама для врагов». Bhujaga здесь задаёт образ сладостного ужаса (garuda-bhujaga): хищник</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:tap|commentary:sundara-lexical:V.51.40" data-filt="unique-vs-1058">
+    <header><div class="hw">√tap @ V.51.40 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма pratāpa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:tap|commentary:sundara-lexical:V.51.40</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:tap</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √tap — цитируется в аппарате на <code>commentary:sundara-lexical:V.51.40</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Пратапа (pratāpa, m.) — «испепеляющий жар (власти), величие, доблесть»; pra- + tāpa (от √tap-, «жечь»). MW: pratāpa &#x27;heat, glow; dignity, power, majesty&#x27;. Pratāpa — политический термин: «жар» царской власти, ощущаемый вассалами и врагами физически. В «Артхашастре» pratāpa — одна из составляющих rajanīti. Связан с tejas, но специфически политичен: если tejas — личное излучение героя, pratāpa — инст</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kruD|commentary:sundara-lexical:V.52.1" data-filt="unique-vs-1058">
+    <header><div class="hw">√krudh @ V.52.1 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма krodhamūrchita</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kruD|commentary:sundara-lexical:V.52.1</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kruD</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √krudh — цитируется в аппарате на <code>commentary:sundara-lexical:V.52.1</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Кродхамурчхита (krodha-mūrchita, adj.) — бахуврихи: krodha «гнев» (от √krudh-, класс IV, Whitney #575, «гневаться») + mūrchita (p.p.p. от √mūrch-, «твердеть, обморочно застывать»). MW: mūrchita &#x27;fainted, swooned; increased, augmented&#x27;. Первичное значение mūrch- — физическое затвердение (ср. mūrcchā «обморок»). Krodha-mūrchita описывает не просто «охваченного гневом», а состояние, где гнев полность</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:ruz|commentary:sundara-lexical:V.53.9" data-filt="unique-vs-1058">
+    <header><div class="hw">√ruṣ @ V.53.9 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма roṣāmarṣa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:ruz|commentary:sundara-lexical:V.53.9</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:ruz</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ruṣ — цитируется в аппарате на <code>commentary:sundara-lexical:V.53.9</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Рошамарша (roṣa-amarṣa, m. dvandva или тат-пуруша) — «гнев и раздражение». roṣa (от √ruṣ-, «раздражаться», класс IV, Whitney #595) = острый гнев, вспышка ярости; amarṣa (от a-√mṛṣ-, «не терпеть, не прощать», класс IV) = негодование, нетерпимость к обиде. MW: roṣa &#x27;anger, passion&#x27;; amarṣa &#x27;non-endurance, impatience of (comp.)&#x27;. Пара не синонимична: roṣa — аффективная реакция (внезапная), amarṣa — о</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:arc|commentary:sundara-lexical:V.53.44" data-filt="unique-vs-1058">
+    <header><div class="hw">√arc @ V.53.44 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма arcimālin</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:arc|commentary:sundara-lexical:V.53.44</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:arc</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √arc — цитируется в аппарате на <code>commentary:sundara-lexical:V.53.44</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Арчималин (arcimālin, adj.) — «в гирлянде лучей / языков пламени»: arci (f.) «луч, язык пламени», от √arc- («сиять», класс I, Whitney #78) + mālin (adj., «носящий гирлянду», от mālā). MW: arcis &#x27;a ray of light, flame&#x27;; mālin &#x27;wearing a garland&#x27;. Двойной смысл: «гирлянда лучей» = солнечные лучи (эпитет Сурьи ārcimālin) И «гирлянда языков пламени» = горящий хвост. Последний стих главы использует ту </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:tfp|commentary:sundara-lexical:V.54.5" data-filt="unique-vs-1058">
+    <header><div class="hw">√tṛp @ V.54.5 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма havyavāhana (saṃtarpaṇa)</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:tfp|commentary:sundara-lexical:V.54.5</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:tfp</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √tṛp — цитируется в аппарате на <code>commentary:sundara-lexical:V.54.5</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Самтарпана (saṃtarpaṇa, n.) — «насыщение, удовлетворение» от saṃ-√tṛp- (насыщать, быть довольным, класс IV/V, Whitney #251). MW: saṃtarpaṇa &#x27;satiation, satisfaction (especially of fire with oblations)&#x27;. В ведийском ритуале огонь (havyavāhana) «насыщается» топлёным маслом (ghṛta) и жертвой. Хануман переворачивает ритуальную логику: богатые дворцы Ланки станут «жертвой» для насыщения огня-хвоста. Эт</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kzi|commentary:sundara-lexical:V.54.24" data-filt="unique-vs-1058">
+    <header><div class="hw">√kṣi @ V.54.24 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма puṇyasaṃkṣaya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kzi|commentary:sundara-lexical:V.54.24</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kzi</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kṣi — цитируется в аппарате на <code>commentary:sundara-lexical:V.54.24</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Пунья-санкшая (puṇya-saṃkṣaya, m.) — тат-пуруша: puṇya «религиозная заслуга, благое кармическое накопление» + saṃkṣaya «исчерпание, уничтожение» (от saṃ-√kṣi-, «убывать»). MW: puṇya &#x27;holy, auspicious; merit&#x27;; saṃkṣaya &#x27;complete destruction, end&#x27;. Образ падающих домов сиддхов сравнивается с павшими домами ракшасов: дома сиддхов разрушаются, когда их накопленные религиозные заслуги (puṇya) иссякают </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:BaYj|commentary:sundara-lexical:V.54.25" data-filt="unique-vs-1058">
+    <header><div class="hw">√bhañj @ V.54.25 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма bhagnotsāha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:BaYj|commentary:sundara-lexical:V.54.25</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:BaYj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhañj — цитируется в аппарате на <code>commentary:sundara-lexical:V.54.25</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Бхагнотсаха (bhagna-utsāha, adj.) — тат-пуруша: bhagna (p.p.p. от √bhañj-, «ломать», класс VII, Whitney #1046) + utsāha «воодушевление, энергия, стойкость» (от ut-√sah-, «держаться, поддерживать»). MW: utsāha &#x27;perseverance, energy; power, strength&#x27;. Utsāha — не просто «стойкость», а активная готовность сражаться и защищать; bhagnotsāha — «сломленный в воле к сопротивлению». Пара bhagnotsāha + jita</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:sah|commentary:sundara-lexical:V.54.25" data-filt="unique-vs-1058">
+    <header><div class="hw">√sah @ V.54.25 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма bhagnotsāha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:sah|commentary:sundara-lexical:V.54.25</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:sah</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sah — цитируется в аппарате на <code>commentary:sundara-lexical:V.54.25</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Бхагнотсаха (bhagna-utsāha, adj.) — тат-пуруша: bhagna (p.p.p. от √bhañj-, «ломать», класс VII, Whitney #1046) + utsāha «воодушевление, энергия, стойкость» (от ut-√sah-, «держаться, поддерживать»). MW: utsāha &#x27;perseverance, energy; power, strength&#x27;. Utsāha — не просто «стойкость», а активная готовность сражаться и защищать; bhagnotsāha — «сломленный в воле к сопротивлению». Пара bhagnotsāha + jita</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:DA|commentary:sundara-lexical:V.54.26" data-filt="unique-vs-1058">
+    <header><div class="hw">√dhā @ V.54.26 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма stanaṃdhaya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:DA|commentary:sundara-lexical:V.54.26</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:DA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhā — цитируется в аппарате на <code>commentary:sundara-lexical:V.54.26</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Станамдхая (stanaṃdhaya, adj./m.) — «сосущий грудь, грудной младенец», от stana «грудь» + dhaya (от √dhā-, «сосать, пить», класс I/III, Whitney #681) в форме stanaṃdhaya — «тот, кто пьёт грудь». MW: stanaṃdhaya &#x27;sucking the breast, an infant&#x27;. Слово — сложный ударный образ: в огне гибнет не абстрактное население, а женщины с грудными детьми — stanaṃdhayadharāḥ striyaḥ. Этот образ — редкий в «герои</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Sap|commentary:sundara-lexical:V.54.41" data-filt="unique-vs-1058">
+    <header><div class="hw">√śap @ V.54.41 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма śāpopahata</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Sap|commentary:sundara-lexical:V.54.41</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Sap</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √śap — цитируется в аппарате на <code>commentary:sundara-lexical:V.54.41</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Шапопахата (śāpa-upahata, adj.) — бахуврихи: śāpa «проклятие» (от √śap-, «проклинать», класс I, Whitney #127) + upahata (p.p.p. от upa-√han-, «поразить, нанести удар»). MW: śāpa &#x27;curse, malediction&#x27;; upahata &#x27;struck, hit; afflicted&#x27;. «Поражённый проклятием» — образ, сравнивающий Ланку с человеком или местом, настигнутым šāpa — мощнейшей формой ритуального наказания в эпосе. Śāpa в индийской традиц</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vA|commentary:sundara-lexical:V.54.49" data-filt="unique-vs-1058">
+    <header><div class="hw">√vā @ V.54.49 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма nirvāpayām āsa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vA|commentary:sundara-lexical:V.54.49</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vā — цитируется в аппарате на <code>commentary:sundara-lexical:V.54.49</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Нирвапаям аса (nirvāpayāṃ āsa, perf. caus.) — «погасил» от ni-√vā- / nir-√vap- → nirvāpa, причинительный залог nirvāpaya. Но лингвистически значимо: √vā- «дуть», и ni-vā → nirvā → nirvāṇa. Это тот же корень, от которого происходит ключевой буддийский термин nirvāṇa («угасание»). Хануман «угашает» огонь в океане — nirvāpayāṃ āsa samudre. В эпосе слово нейтрально, «погасил», но для читателя, знакомо</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vap|commentary:sundara-lexical:V.54.49" data-filt="unique-vs-1058">
+    <header><div class="hw">√vap @ V.54.49 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма nirvāpayām āsa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vap|commentary:sundara-lexical:V.54.49</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vap</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vap — цитируется в аппарате на <code>commentary:sundara-lexical:V.54.49</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Нирвапаям аса (nirvāpayāṃ āsa, perf. caus.) — «погасил» от ni-√vā- / nir-√vap- → nirvāpa, причинительный залог nirvāpaya. Но лингвистически значимо: √vā- «дуть», и ni-vā → nirvā → nirvāṇa. Это тот же корень, от которого происходит ключевой буддийский термин nirvāṇa («угасание»). Хануман «угашает» огонь в океане — nirvāpayāṃ āsa samudre. В эпосе слово нейтрально, «погасил», но для читателя, знакомо</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kup|commentary:sundara-lexical:V.55.3" data-filt="unique-vs-1058">
+    <header><div class="hw">√kup @ V.55.3 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма kopa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kup|commentary:sundara-lexical:V.55.3</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kup</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kup — цитируется в аппарате на <code>commentary:sundara-lexical:V.55.3</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Копа (kopa, m.) — «гнев, вспышка раздражения», от √kup- (класс IV, Whitney #660, «кипеть, бурлить, злиться»). MW: kopa &#x27;anger, wrath&#x27;. Апте: kopa «passion, rage». В стихе противопоставлено buddhi «разуму»: «великодушные те, кто разумом (buddhyā) сдерживают вспыхнувший гнев». Корень √kup- родствен лат. cupio («страстно желать») — исходное значение «кипение, бурление»; в санскрите специализировалось</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:as|commentary:sundara-lexical:V.55.12" data-filt="unique-vs-1058">
+    <header><div class="hw">√as @ V.55.12 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма prāṇasaṃnyāsa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:as|commentary:sundara-lexical:V.55.12</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:as</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √as — цитируется в аппарате на <code>commentary:sundara-lexical:V.55.12</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Пранасамньяса (prāṇa-saṃnyāsa, m.) — тат-пуруша: prāṇa «жизнь, дыхание» (√an-, «дышать», с префиксом pra-) + saṃnyāsa «отложение, отречение, сложение» (sam+ni+√as-, «бросать вниз»). MW: saṃnyāsa &#x27;laying down, abandonment; the last āśrama&#x27;. В ведантийской традиции saṃnyāsa — четвёртый ашрам, «сложение всего мирского», включая тело. Здесь Хануман буквально рассматривает prāṇasaṃnyāsa как «сложение ж</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:tij|commentary:sundara-lexical:V.55.22" data-filt="unique-vs-1058">
+    <header><div class="hw">√tij @ V.55.22 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма tejas</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:tij|commentary:sundara-lexical:V.55.22</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:tij</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √tij — цитируется в аппарате на <code>commentary:sundara-lexical:V.55.22</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Теджас (tejas, n.) — «острота, жар, огонь, сияние, духовная мощь», от √tij- (каузативная форма √taj-, «быть острым»). MW: tejas &#x27;sharpness, fire, heat; vital power, energy, majesty&#x27;. Апте: tejas «the bright appearance of anything, lustre, light; courage, dignity». В стихе: «прекрасная Джанаки защищена своим собственным теджасом (svena tejasā)». Теджас здесь — нравственно-духовная «острота», защитн</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:hu|commentary:sundara-lexical:V.55.24" data-filt="unique-vs-1058">
+    <header><div class="hw">√hu @ V.55.24 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма havyavāhana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:hu|commentary:sundara-lexical:V.55.24</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:hu</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √hu — цитируется в аппарате на <code>commentary:sundara-lexical:V.55.24</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Хавьявахана (havya-vāhana, m.) — эпитет Агни: havya «приношение, жертвенная пища» (от √hu-, «возливать жертву») + vāhana «несущий, возница» (√vah-, «везти, нести», Whitney #761). MW: havyavāhana &#x27;fire (as carrying the oblation)&#x27;. Огонь — «носитель жертвы» к богам: он несёт (vāhana) то, что должно быть возлитым (havya). Эпитет восходит к ведийской концепции Агни как посредника между миром людей и б</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vah|commentary:sundara-lexical:V.55.24" data-filt="unique-vs-1058">
+    <header><div class="hw">√vah @ V.55.24 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма havyavāhana</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vah|commentary:sundara-lexical:V.55.24</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vah</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vah — цитируется в аппарате на <code>commentary:sundara-lexical:V.55.24</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Хавьявахана (havya-vāhana, m.) — эпитет Агни: havya «приношение, жертвенная пища» (от √hu-, «возливать жертву») + vāhana «несущий, возница» (√vah-, «везти, нести», Whitney #761). MW: havyavāhana &#x27;fire (as carrying the oblation)&#x27;. Огонь — «носитель жертвы» к богам: он несёт (vāhana) то, что должно быть возлитым (havya). Эпитет восходит к ведийской концепции Агни как посредника между миром людей и б</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:as|commentary:sundara-lexical:V.55.28" data-filt="unique-vs-1058">
+    <header><div class="hw">√as @ V.55.28 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма satya-vākya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:as|commentary:sundara-lexical:V.55.28</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:as</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √as — цитируется в аппарате на <code>commentary:sundara-lexical:V.55.28</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Сатьявакья (satya-vākya, n.) — «речение истины, обет правдивости»: satya «истинное, настоящее» (p.p.p. от √as-, «быть», буквально «действительно существующее») + vākya «высказывание» (√vac-, «говорить»). MW: satyavakya &#x27;truthfulness of speech&#x27;. В индийской эпической традиции satyavākya — не просто «правдивость», но онтологическое соответствие слова реальности: произнесённое в ритуальном контексте </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vac|commentary:sundara-lexical:V.55.28" data-filt="unique-vs-1058">
+    <header><div class="hw">√vac @ V.55.28 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма satya-vākya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vac|commentary:sundara-lexical:V.55.28</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vac</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vac — цитируется в аппарате на <code>commentary:sundara-lexical:V.55.28</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Сатьявакья (satya-vākya, n.) — «речение истины, обет правдивости»: satya «истинное, настоящее» (p.p.p. от √as-, «быть», буквально «действительно существующее») + vākya «высказывание» (√vac-, «говорить»). MW: satyavakya &#x27;truthfulness of speech&#x27;. В индийской эпической традиции satyavākya — не просто «правдивость», но онтологическое соответствие слова реальности: произнесённое в ритуальном контексте </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:diS|commentary:sundara-lexical:V.56.1" data-filt="unique-vs-1058">
+    <header><div class="hw">√diś @ V.56.1 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма diṣṭyā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:diS|commentary:sundara-lexical:V.56.1</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:diS</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √diś — цитируется в аппарате на <code>commentary:sundara-lexical:V.56.1</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Дишть (diṣṭyā, indecl.) — «счастье! слава судьбе!» — замёрзшая форма инструментала от diṣṭi «судьба, предназначение» (√diś-, «указывать», Whitney #410). MW: diṣṭyā &#x27;luckily, fortunately&#x27; (an exclamation of joy). Буквально: «(я вижу тебя) по (указанию) судьбы» → «к счастью!». Слово используется исключительно как возглас удовлетворения или облегчения при виде желанного; параллель: гр. μοῖρα «судьба»</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Baj|commentary:sundara-lexical:V.56.4" data-filt="unique-vs-1058">
+    <header><div class="hw">√bhaj @ V.56.4 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма alpabhāgya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Baj|commentary:sundara-lexical:V.56.4</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Baj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhaj — цитируется в аппарате на <code>commentary:sundara-lexical:V.56.4</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Альпабхагья (alpa-bhāgya, adj.) — «несчастливая, малодоля»: alpa «малый, ничтожный» + bhāgya «доля, судьба, счастье» (p.p.p. от √bhaj-, «делить, получать долю», Whitney #505). MW: bhāgya &#x27;auspicious, lucky; fate, lot&#x27;. Сита называет себя alpabhāgyāḥ — «малодольной» — что в эпическом санскрите является формульным самоумалением страдающей женщины. Bhāgya — «то, что отведено в долю» — онтологически п</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:ruh|commentary:sundara-lexical:V.56.20" data-filt="unique-vs-1058">
+    <header><div class="hw">√ruh @ V.56.20 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма rohiṇī</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:ruh|commentary:sundara-lexical:V.56.20</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:ruh</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √ruh — цитируется в аппарате на <code>commentary:sundara-lexical:V.56.20</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Рохини (rohiṇī, f.) — «красно-рыжая», от √ruh- («подниматься, расти», Whitney #765) с суффиксом цвета -iṇī: «восходящая, рдеющая». Rohiṇī — любимая жена Луны (Candra), соответствующая созвездию Альдебаран (α Tauri). MW: rohiṇī &#x27;the favorite wife of the moon&#x27;. Сравнение Ситы с Рохини, воссоединившейся с Месяцем (śaśāṅkena) — точная астрономическая метафора: Луна движется по эклиптике и «возвращаетс</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Df|commentary:sundara-lexical:V.56.50" data-filt="unique-vs-1058">
+    <header><div class="hw">√dhṛ @ V.56.50 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма dharaṇīdhara</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Df|commentary:sundara-lexical:V.56.50</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Df</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.56.50</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Дхарани-дхара (dharaṇī-dhara, m.) — «держатель земли» = гора: dharaṇī «земля» (от √dhṛ-, «держать», с суфф. -aṇī; «то, что держит [всё]») + dhara «держащий» (от того же √dhṛ-). MW: dharaṇīdhara &#x27;a mountain&#x27;. Тавтологическая этимология — «держатель-держателя» — указывает на устойчивость горы как опоры мироздания; ведийская концепция гор как «столпов земли» (пилонов, держащих небо и землю). В данном</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:tF|commentary:sundara-lexical:V.57.5" data-filt="unique-vs-1058">
+    <header><div class="hw">√tṝ @ V.57.5 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма tārādhipa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:tF|commentary:sundara-lexical:V.57.5</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:tF</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √tṝ — цитируется в аппарате на <code>commentary:sundara-lexical:V.57.5</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Тарадхипа (tārā-dhipa, m.) — «владыка звёзд» = Луна: tārā «звезда» (от √tṝ-, «пересекать»; звёзды «пересекают» небо) + dhipa = adhipa «господин» (adhi+pa, «охраняющий»). MW: tārādhipa &#x27;the moon (lord of the stars)&#x27;. В стихе Хануман летит «как будто выцарапывая (ullikhan) луну» — ollikhant как «скребущий по» небесному своду. Образ луны-«повелителя звёзд» контрастирует с Хануманом — «сыном ветра» (в</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Dav|commentary:sundara-lexical:V.57.9" data-filt="unique-vs-1058">
+    <header><div class="hw">√dhav @ V.57.9 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма dhavalāmbara</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Dav|commentary:sundara-lexical:V.57.9</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Dav</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhav — цитируется в аппарате на <code>commentary:sundara-lexical:V.57.9</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Дхавалмбара (dhavala-ambara, adj.) — «одетый в белое/белое-небо»: dhavala «ярко-белый» (от √dhav-, «промывать добела»?) + ambara «небо; одежда» (am+√bṛ-, «окружать, покрывать»). MW: ambara &#x27;sky, atmosphere; a garment&#x27;. Семантическое богатство ambara — «и небо, и одежда» — создаёт двойную метафору: Хануман «одет в белое небо» (т.е. летит в белом пространстве облаков) И «его одежда — небо» (образ бо</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:aYc|commentary:sundara-lexical:V.57.14" data-filt="unique-vs-1058">
+    <header><div class="hw">√añc @ V.57.14 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма nārāca</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:aYc|commentary:sundara-lexical:V.57.14</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:aYc</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √añc — цитируется в аппарате на <code>commentary:sundara-lexical:V.57.14</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Нарача (nārāca, m.) — «железная стрела» (особый тип): nāra «человек/вода»? + āca «гнутый» (√añc-)? — этимология спорная; MW: nārāca &#x27;an iron arrow&#x27;. Апте: nārāca «an iron arrow, esp. one entirely of iron (as opposed to one with a wooden shaft)». Хануман сравнивается с nārāca, пущенной с тетивы (jyāmukta iva nārāco mahāvego &#x27;bhyupāgamat). Цельнометаллическая стрела (nārāca) в отличие от деревянной </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:dA|commentary:sundara-lexical:V.57.46" data-filt="unique-vs-1058">
+    <header><div class="hw">√dā @ V.57.46 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма jīvita-pradātṛ</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:dA|commentary:sundara-lexical:V.57.46</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:dA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dā — цитируется в аппарате на <code>commentary:sundara-lexical:V.57.46</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Дживитапрадатри (jīvita-pradātṛ, m.) — «даритель жизни»: jīvita «жизнь» (p.p.p. от √jīv-, «жить») + pradātṛ «дающий» (pra+√dā-, «давать», агентивный суфф. -tṛ). MW: jīvita &#x27;life; alive&#x27;. Ангада называет Ханумана «единственным дарителем нашей жизни (jīvitasya pradātā nas tvam eko vānarōttama)». В индийской дарственной терминологии pradātṛ — юридический / ритуальный «даритель», создающий обязательст</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:jIv|commentary:sundara-lexical:V.57.46" data-filt="unique-vs-1058">
+    <header><div class="hw">√jīv @ V.57.46 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма jīvita-pradātṛ</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:jIv|commentary:sundara-lexical:V.57.46</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:jIv</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √jīv — цитируется в аппарате на <code>commentary:sundara-lexical:V.57.46</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Дживитапрадатри (jīvita-pradātṛ, m.) — «даритель жизни»: jīvita «жизнь» (p.p.p. от √jīv-, «жить») + pradātṛ «дающий» (pra+√dā-, «давать», агентивный суфф. -tṛ). MW: jīvita &#x27;life; alive&#x27;. Ангада называет Ханумана «единственным дарителем нашей жизни (jīvitasya pradātā nas tvam eko vānarōttama)». В индийской дарственной терминологии pradātṛ — юридический / ритуальный «даритель», создающий обязательст</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Df|commentary:sundara-lexical:V.57.47" data-filt="unique-vs-1058">
+    <header><div class="hw">√dhṛ @ V.57.47 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма dhṛti</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Df|commentary:sundara-lexical:V.57.47</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Df</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.57.47</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Дхрити (dhṛti, f.) — «стойкость, выдержка, решимость», от √dhṛ- («держать, сохранять», Whitney #612). MW: dhṛti &#x27;holding, seizing; firmness, constancy, resolution&#x27;. Апте: dhṛti «steadiness of mind, fortitude, patience». В восклицании Ангады: aho svāmini te bhaktir aho vīryam aho dhṛtiḥ — «ах, твоя преданность господину! ах, твоя доблесть! ах, твоя стойкость!» — dhṛti занимает последнее, кульминаци</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kf|commentary:sundara-lexical:V.58.115" data-filt="unique-vs-1058">
+    <header><div class="hw">√kṛ @ V.58.115 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма kiṃkara</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kf|commentary:sundara-lexical:V.58.115</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.58.115</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Кинкара (kiṃkara, m.) — слуга, букв. делающий то, что скажут (kiṃ «что?» + kara «делающий» &lt; √kṛ-). MW: kiṃkara «слуга, раб». Формульная этимология имени намеренна: kiṃ (вопросительная частица) + kara = «делающий всё по приказу». В V.58.115 кинкары характеризуются как mano&#x27;nugā («следующие духу/воле господина»), что дублирует и усиляет этимологический смысл. Их число 80 000, вооружение śūla+mudgar</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vaD|commentary:sundara-lexical:V.58.149" data-filt="unique-vs-1058">
+    <header><div class="hw">√vadh @ V.58.149 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма dūta-vadhyā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vaD|commentary:sundara-lexical:V.58.149</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vaD</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vadh — цитируется в аппарате на <code>commentary:sundara-lexical:V.58.149</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Дута-вадхья (dūta-vadhyā) — «убийство посла» (dūta «посол» + vadhyā «[тот], кого следует убить»; vadhya — gerundive от √vadh-). MW: dūta «посланник, гонец»; vadhya «заслуживающий смерти». В речи Вибхишаны (V.58.148-149) звучит редкий в эпосе эксплицитный политико-правовой аргумент: «убийство посланца не практикуется в rāja-śāstra». Ср. Артхашастра I.16: dūta неприкосновенен даже при враждебных отн</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:as|commentary:sundara-lexical:V.59.5" data-filt="unique-vs-1058">
+    <header><div class="hw">√as @ V.59.5 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма satī</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:as|commentary:sundara-lexical:V.59.5</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:as</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √as — цитируется в аппарате на <code>commentary:sundara-lexical:V.59.5</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Сати (satī, f.) — «истинная, добродетельная; сама добродетель», f. от sat (p.p.p. от √as-, «быть»; дословно «сущая», «истинная»). MW: satī &#x27;a virtuous woman, faithful wife; a woman who burns herself with her husband&#x27;s body&#x27;. В стихе «agniśikhā saṃspṛṣṭā pāṇinā satī» — «пламя, которого коснулась рукой сати (добродетельная женщина)». Satī здесь — не обряд самосожжения (это более позднее значение), а</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Baj|commentary:sundara-lexical:V.59.32" data-filt="unique-vs-1058">
+    <header><div class="hw">√bhaj @ V.59.32 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма mahābhāgā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Baj|commentary:sundara-lexical:V.59.32</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Baj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhaj — цитируется в аппарате на <code>commentary:sundara-lexical:V.59.32</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Махабхага (mahā-bhāgā, f.) — «наделённая великой долей / великим счастьем»: mahā «великий» + bhāgā f. «доля, удел» (от √bhaj-, «делить, одарять»). MW: mahābhāga &#x27;highly fortunate, eminent&#x27;. Bhāga — «то, что выделено» (ср. lak-ṣmī — «богатство судьбы», Fortuna). Mahābhāgā — формульный эпитет в ситуациях, когда велика «обречённость» судьбы: великая доля означает и великое испытание. Он применяется к</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:pA|commentary:sundara-lexical:V.60.2" data-filt="unique-vs-1058">
+    <header><div class="hw">√pā @ V.60.2 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма pitāmaha</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:pA|commentary:sundara-lexical:V.60.2</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:pA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √pā — цитируется в аппарате на <code>commentary:sundara-lexical:V.60.2</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Питамаха (pitāmaha, m.) — «дед, прадед», буквально «[великий] отец отца»: pitā «отец» (от √pā-/√pitṛ-, и.-е. *ph₂tḗr) + maha «великий» (√mah-). MW: pitāmaha &#x27;a paternal grandfather; Brahmā (as progenitor of the world)&#x27;. В стихе «sarvalokapitāmahaḥ» — «Праотец всех миров» = Брахма. Pitāmaha в эпосе — регулярный эпитет Брахмы, подчёркивающий его статус генеалогического истока бытия (ср. prajāpati). </blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:div|commentary:sundara-lexical:V.60.8" data-filt="unique-vs-1058">
+    <header><div class="hw">√div @ V.60.8 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма devī</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:div|commentary:sundara-lexical:V.60.8</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:div</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √div — цитируется в аппарате на <code>commentary:sundara-lexical:V.60.8</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Деви (devī, f.) — «богиня; царица, госпожа», f. от deva (от √div-, «сиять»). MW: devī &#x27;a goddess; a queen&#x27;. В докладе Ангады «dṛṣṭā devī na cānītā» — «нашли мы devī, но не привели». Devī применительно к Сите — почётный титул (= rājapatnī, «жена царевича»), но слово одновременно несёт коннотацию сакрального: devī = земная богиня. Ангада использует этот статусный термин, обращаясь к Раме — подчёркив</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:jYA|commentary:sundara-lexical:V.60.17" data-filt="unique-vs-1058">
+    <header><div class="hw">√jñā @ V.60.17 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма pratijñā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:jYA|commentary:sundara-lexical:V.60.17</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:jYA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √jñā — цитируется в аппарате на <code>commentary:sundara-lexical:V.60.17</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Пратиджня (pratijñā, f.) — «публично данное обещание, клятва»: prati («против, перед») + √jñā- («знать, признавать»; Whitney #670). MW: pratijñā &#x27;promise, vow, assertion&#x27;. В стихе: rāghavo «pratijñāya svayaṃ rājā sītāvijayam agrahaḥ» — «сам дав обещание всем вождям [вернуть] победу Ситы». Pratijñā в дхармашастрах — юридически обязывающий акт: публичная клятва, данная перед svayambhu (самосущими св</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:sfj|commentary:sundara-lexical:V.61.12" data-filt="unique-vs-1058">
+    <header><div class="hw">√sṛj @ V.61.12 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма nisarga</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:sfj|commentary:sundara-lexical:V.61.12</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:sfj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sṛj — цитируется в аппарате на <code>commentary:sundara-lexical:V.61.12</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Нисарга (nisarga, m.) — «дозволение, дар, естественный порядок», от ni+√sṛj- («выпускать, отпускать»). MW: nisarga &#x27;giving away, abandonment; natural state or condition; nature, instinct&#x27;. Термин несёт два смысловых слоя: (1) юридический — nisarga как «разрешение», официальное освобождение от ограничений (ср. dharmaśāstric «nisarga права»); (2) природный — «то, что отпущено на свободу, естественно</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:sU|commentary:sundara-lexical:V.61.13" data-filt="unique-vs-1058">
+    <header><div class="hw">√sū @ V.61.13 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма valisūnu</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:sU|commentary:sundara-lexical:V.61.13</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:sU</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sū — цитируется в аппарате на <code>commentary:sundara-lexical:V.61.13</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Валисуну (vali-sūnu, m.) — тат-пуруша: Vālin (имя царя обезьян, убитого Рамой) + sūnu «сын» (от √sū-, «рождать», MW: sūnu &#x27;son, child&#x27;). Патронимический эпитет Ангады. Sūnu архаичнее и торжественнее, чем putra или ātmaja: характерен для эпических патронимиков героев (ср. Pāṇḍusūnu = сыновья Панду). Особая коннотация: Vālin — убитый отец, жертва союзника Ангады (Рамы). Эпитет vali-sūnu в сцене, где</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Dfz|commentary:sundara-lexical:V.61.23" data-filt="unique-vs-1058">
+    <header><div class="hw">√dhṛṣ @ V.61.23 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма pradharṣaṇa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Dfz|commentary:sundara-lexical:V.61.23</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Dfz</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhṛṣ — цитируется в аппарате на <code>commentary:sundara-lexical:V.61.23</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Прадхаршана (pra-dharṣaṇa, n.) — от pra+√dhṛṣ- («дерзать, нападать, преодолевать страх», Whitney #182 дерив.): «нападение, насилие, дерзкое попрание». MW: dharṣaṇa &#x27;overcoming, overpowering; violation, assault&#x27;. Юридико-дхармический термин: dharṣaṇa / pradharṣaṇa — специальное слово для нарушения табу и неприкосновенности чужого (ср. strī-dharṣaṇa — «насилие над женщиной» как тяжкое преступление в</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:aMS|commentary:sundara-lexical:V.62.35" data-filt="unique-vs-1058">
+    <header><div class="hw">√aṃś @ V.62.35 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма sahasrāṃśusuta</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:aMS|commentary:sundara-lexical:V.62.35</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:aMS</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √aṃś — цитируется в аппарате на <code>commentary:sundara-lexical:V.62.35</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Сахасрамшусута (sahasra-aṃśu-suta, m.) — «сын тысячелучного [солнца]» = Сугрива: sahasra «тысяча» + aṃśu «луч» (√aṃś-, «иметь часть, сиять»?) + suta «сын» (p.p.p. от √su-, «рожать»). MW: sahasrāṃśu &#x27;the sun (having thousand rays)&#x27;. Сугрива — сын Сурьи, бога солнца. Эпитет «тысячелучное солнце» применён к Сурье (не к Сугриве): sahasrāṃśu-suta = «сын тысячелучного» = «сын Сурьи». В повествовательном</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:su|commentary:sundara-lexical:V.62.35" data-filt="unique-vs-1058">
+    <header><div class="hw">√su @ V.62.35 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма sahasrāṃśusuta</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:su|commentary:sundara-lexical:V.62.35</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:su</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √su — цитируется в аппарате на <code>commentary:sundara-lexical:V.62.35</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Сахасрамшусута (sahasra-aṃśu-suta, m.) — «сын тысячелучного [солнца]» = Сугрива: sahasra «тысяча» + aṃśu «луч» (√aṃś-, «иметь часть, сиять»?) + suta «сын» (p.p.p. от √su-, «рожать»). MW: sahasrāṃśu &#x27;the sun (having thousand rays)&#x27;. Сугрива — сын Сурьи, бога солнца. Эпитет «тысячелучное солнце» применён к Сурье (не к Сугриве): sahasrāṃśu-suta = «сын тысячелучного» = «сын Сурьи». В повествовательном</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:BI|commentary:sundara-lexical:V.63.2" data-filt="unique-vs-1058">
+    <header><div class="hw">√bhī @ V.63.2 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма abhaya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:BI|commentary:sundara-lexical:V.63.2</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:BI</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhī — цитируется в аппарате на <code>commentary:sundara-lexical:V.63.2</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>«Абхая» (abhaya, n.) — «отсутствие страха; безопасность», a-bhaya, от √bhī- («бояться», Whitney #747, класс III; и.-е. *bʰeygʰ-). MW: abhaya &#x27;absence of fear, security&#x27;. В формуле abhayaṃ te pradāsyāmi («дарую тебе убежище от страха») — это не просто успокоение, но abhayapradāna — признанная в дхармашастре категория дарения: Ману (4.232) ставит abhayapradāna выше дарения земли и золота. Артхашастр</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:so|commentary:sundara-lexical:V.63.21" data-filt="unique-vs-1058">
+    <header><div class="hw">√so @ V.63.21 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма vyavasāya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:so|commentary:sundara-lexical:V.63.21</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:so</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √so — цитируется в аппарате на <code>commentary:sundara-lexical:V.63.21</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>«Вьявасая» (vyavasāya, m.) — «твёрдая решимость, волевая определённость», vi-ava-√so- (выжимать, выдавливать до конца; MW: √so- &#x27;to finish, destroy&#x27;): vi+ava+sā → «выжать до конца = окончательно решить». MW: vyavasāya &#x27;exertion, effort; determination, resolution; industry&#x27;. В эпической этике vyavasāya принципиально отличается от saṃkalpa («намерения, обета»): saṃkalpa — ментальное решение, vyavasā</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:sad|commentary:sundara-lexical:V.64.16" data-filt="unique-vs-1058">
+    <header><div class="hw">√sad @ V.64.16 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма prasāda</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:sad|commentary:sundara-lexical:V.64.16</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:sad</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √sad — цитируется в аппарате на <code>commentary:sundara-lexical:V.64.16</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Праса́да (prasāda, m.) — «ясность, умиротворение, благодать», pra+√sad- («садиться, оседать», о жидкости — «проясняться»). MW: prasāda &#x27;clearness; graciousness&#x27;. Prasāda жидкости = когда муть оседает и вода становится прозрачной — прямая метафора ума, «успокаивающегося» от гнева. В более позднем теологическом словаре prasāda = «благодать бога», «остаток ритуальной пищи». Здесь — в классическом зна</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:hfz|commentary:sundara-lexical:V.64.29" data-filt="unique-vs-1058">
+    <header><div class="hw">√hṛṣ @ V.64.29 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма harṣa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:hfz|commentary:sundara-lexical:V.64.29</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:hfz</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √hṛṣ — цитируется в аппарате на <code>commentary:sundara-lexical:V.64.29</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Харша (harṣa, m.) — «радость, ликование; ощущение приятного холодка (мурашки)», от √hṛṣ- (класс IV, «радоваться, ощущать приятный озноб», Whitney #744). MW: harṣa &#x27;bristling (of hair); joy&#x27;. Корень √hṛṣ- описывает физическое состояние: волоски на теле встают дыбом от радостного возбуждения. Harṣa = радость, буквально «мурашки», телесный ответ на эмоцию. Ср. romāñca (то же явление, «вздыбленные вол</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kf|commentary:sundara-lexical:V.65.2" data-filt="unique-vs-1058">
+    <header><div class="hw">√kṛ @ V.65.2 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма puraskṛtya</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kf|commentary:sundara-lexical:V.65.2</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.65.2</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Пуракртья (puras-kṛtya, abs.) — «выдвинув вперёд, поставив во главе», puras («перед, впереди») + kṛtya (abs. от √kṛ-). MW: puraskṛta &#x27;placed in front; honoured&#x27;. Puraskāra / puraskṛ — протокольный глагол церемониального старшинства: поставить кого-то впереди значит признать его приоритет. Вандары идут к Раме, поставив впереди Ангаду-юварадже: жест политической осторожности — дать первому слово том</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vft|commentary:sundara-lexical:V.65.6" data-filt="unique-vs-1058">
+    <header><div class="hw">√vṛt @ V.65.6 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма vṛttānta</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vft|commentary:sundara-lexical:V.65.6</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vft</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vṛt — цитируется в аппарате на <code>commentary:sundara-lexical:V.65.6</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Врттанта (vṛttānta, m.) — «происшедшее, повествование о случившемся», vṛtta (p.p.p. от √vṛt-, «совершаться, происходить») + anta («конец, завершение»). MW: vṛttānta &#x27;what has occurred, an account, report&#x27;. Технически: полный нарратив от начала до конца события. Hanuman назван sītā-vṛttānta-kovida — «знаток истории Ситы»: не просто очевидец, а specialist по полному нарративу. Kovida (√ku-/vid-, «зн</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Baj|commentary:sundara-lexical:V.65.18" data-filt="unique-vs-1058">
+    <header><div class="hw">√bhaj @ V.65.18 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×2</span><span class="badge">лемма bhakti</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Baj|commentary:sundara-lexical:V.65.18</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Baj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhaj — цитируется в аппарате на <code>commentary:sundara-lexical:V.65.18</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Бхакти (bhakti, f.) — «причастность, доля; преданность», от √bhaj- («делить, принимать участие, почитать», Whitney #742). MW: bhakti &#x27;distribution; devotion, loyalty&#x27;. Исходное значение √bhaj-: делить пищу между участниками трапезы — тот, кто получает свою долю (bhāga), тот и участвует. Bhakti = «делание себя частью», «причастность» — до позднего бхакти-движения, где слово получает теологическое з</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:vft|commentary:sundara-lexical:V.67.2" data-filt="unique-vs-1058">
+    <header><div class="hw">√vṛt @ V.67.2 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма pūrvavṛtta</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:vft|commentary:sundara-lexical:V.67.2</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:vft</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √vṛt — цитируется в аппарате на <code>commentary:sundara-lexical:V.67.2</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Пурвавритта (pūrva-vṛtta, n.) — «прежде случившееся, прошлое событие», pūrva («прежний, первый») + vṛtta (p.p.p. от √vṛt-, «вращаться, происходить», Whitney #543). MW: pūrva &#x27;former, prior&#x27;; vṛtta &#x27;happened, occurred; an occurrence, event&#x27;. В контексте abhijñāna-сцены pūrvavṛttam несёт конкретную нагрузку: это не просто «воспоминание» (smṛti), а событие, которое оба участника пережили и которое по</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kf|commentary:sundara-lexical:V.67.23" data-filt="unique-vs-1058">
+    <header><div class="hw">√kṛ @ V.67.23 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма duṣkṛta</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kf|commentary:sundara-lexical:V.67.23</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kf</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kṛ — цитируется в аппарате на <code>commentary:sundara-lexical:V.67.23</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Душкрита (duṣ-kṛta, n.) — «дурно совершённое, грех», duṣ- (приставка ухудшения) + kṛta (p.p.p. от √kṛ-, «делать»). MW: duṣkṛta &#x27;evil action, sin, guilt; wickedly done&#x27;. В эпосе duṣkṛta — конкретный грех как причинно-следственный акт кармы: Сита не риторически сетует, а рассуждает логически в терминах кармического объяснения (kiṃ cin mahad asti na saṃśayaḥ, «наверняка есть какой-то большой грех — с</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:Baj|commentary:sundara-lexical:V.68.4" data-filt="unique-vs-1058">
+    <header><div class="hw">√bhaj @ V.68.4 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма alpabhāgyā</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:Baj|commentary:sundara-lexical:V.68.4</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:Baj</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √bhaj — цитируется в аппарате на <code>commentary:sundara-lexical:V.68.4</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Альпабхагья (alpa-bhāgyā, f.) — «наделённая малой долей (судьбы)», alpa («маленький, ничтожный») + bhāgya («удел, судьба, счастье», от √bhaj- «разделять», Whitney #517). MW: alpabhāgya &#x27;having little fortune, unfortunate&#x27;. Самоопределение Ситы mama cāpy alpabhāgyāyāḥ — «а у меня, обделённой счастьем» — работает в терминах концепции daiva / bhāgya: судьба как заранее распределённая «доля» существа.</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:pac|commentary:sundara-lexical:V.68.4" data-filt="unique-vs-1058">
+    <header><div class="hw">√pac @ V.68.4 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма śokavipāka</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:pac|commentary:sundara-lexical:V.68.4</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:pac</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √pac — цитируется в аппарате на <code>commentary:sundara-lexical:V.68.4</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Шокавипака (śoka-vipāka, m.) — «плод / созревание скорби», śoka + vipāka (vi+√pac-, «созревать, вариться», Whitney #758; MW: vipāka &#x27;ripeness, maturation; the consequence of past actions&#x27;). Термин vipāka восходит к агрономической метафоре: зерно вызревает → последствие (karma) «вызревает» → даёт плод. Śoka-vipāka = скорбь, достигшая полного созревания, вся сила которой теперь ощущается. Апте: vipā</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:DA|commentary:sundara-lexical:V.68.13" data-filt="unique-vs-1058">
+    <header><div class="hw">√dhā @ V.68.13 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма upādhi</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:DA|commentary:sundara-lexical:V.68.13</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:DA</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √dhā — цитируется в аппарате на <code>commentary:sundara-lexical:V.68.13</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Упадхи (upādhi, m.) — «уловка, обман, хитрость, подмена», upa- + ādhi (√dhā-, «класть»; буквально «подкладывание»). MW: upādhi &#x27;a condition, qualification; fraud, imposition, disguise&#x27;. В 68.13 Сита характеризует похищение Раваной: vanād upadhinā hṛtā «похищена из леса при помощи upadhi». Upādhi здесь — конкретная хитрость с золотым оленем (Mārica): форма мошенничества, а не открытое нападение. Те</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+
+  <section class="card" data-id="root:kfz|commentary:sundara-lexical:V.68.22" data-filt="unique-vs-1058">
+    <header><div class="hw">√kṛṣ @ V.68.22 <span class="badge">✅ уникально против 1058</span><span class="badge">evidence ×1</span><span class="badge">лемма prakṛṣṭa</span></div><span class="idchip" title="card id — cite this id back when discussing this card">root:kfz|commentary:sundara-lexical:V.68.22</span></header>
+    <div class="question"><p>Тип-D связь: грамматический якорь <code>root:kfz</code> — корень из инвентаря WhitneyRoots mw_roots, здесь корень √kṛṣ — цитируется в аппарате на <code>commentary:sundara-lexical:V.68.22</code>, стих аппарата lexical кн. V Сундараканды.</p><p>Подтвердить строку конкорданса в подтверждённый ярус (после голоса — единственный путь записи)?</p></div>
+    <div class="panel"><h4>примечание слоя lexical (фрагмент)</h4><blockquote>Пракришта (prakṛṣṭa, adj.) — «выдающийся, лучший», pra- (усил.) + kṛṣṭa (p.p.p. от √kṛṣ-, «тянуть, влечь», Whitney #267). MW: prakṛṣṭa &#x27;drawn forward, eminent, excellent&#x27;. Хануман формулирует принцип na hi prakṛṣṭāḥ preṣyante / preṣyante hītare janāḥ — «лучших не посылают, посылают людей по чину ниже». Это стандартный принцип дипломатии и военной стратегии: prakṛṣṭa сберегается для финального удар</blockquote></div><div class="panel"><h4>дедупликация против 1058 Леонова/Костиной</h4><p>✅ уникально против 1058</p></div>
+    <div class="controls">
+      <button class="vote approve" data-vote="approve">&#9989; ✅ подтвердить связь</button>
+      <button class="vote reject" data-vote="reject">&#10060; ❌ снять строку</button>
+      <button class="vote defer" data-vote="defer">&#9208; Defer</button>
+      <span class="vote-state">unvoted</span>
+    </div>
+    <textarea class="note" placeholder="Почему отклоняете/откладываете (для reject/defer обязательно)"></textarea>
+  </section>
+</div>
+</main>
+<div class="votebar" id="voteBar"><span class="spacer"></span></div>
+<footer class="hint">Ворота записи: НИЧЕГО не пишется ни в какой стор до голоса (Fail = store write мимо человеческих ворот). Дедупликация против 1058 примечаний Леонова/Костиной посчитана заранее и показана на карточке; строки ⚠ ранжированы первыми. Keyboard: <kbd>a</kbd> ✅ подтвердить связь &middot; <kbd>r</kbd> ❌ снять строку
+  &middot; <kbd>d</kbd> defer &middot; <kbd>&darr;</kbd>/<kbd>&uarr;</kbd> next/prev. Votes autosave to
+  this browser's localStorage; click "Download decisions.json" when done (unvoted items export with
+  decision:null).</footer>
+<div class="legend" style="max-width:980px;margin:0 auto 20px;padding:0 20px;color:var(--muted);font-size:12px">
+  <b>Approve</b> = accept the proposed change/answer shown on the card (no separate "approve as-is" —
+  approving means agreeing as written). <b>Reject</b> = keep the current entry/answer unchanged.
+  <b>Defer</b> = not sure yet, decide later. The note field is for requesting a partial tweak instead
+  of an outright reject.
+</div>
+<script>
+(function () {
+  var SHEET_ID = "commentarystrategies-sundarakanda-typed-link-q41";
+  var STORE_KEY = 'review-sheet:' + SHEET_ID;
+  var GENERATED = "26-08-2026";
+  var ids = ["root:kfS|commentary:sundara-lexical:V.1.1", "root:DA|commentary:sundara-lexical:V.1.5", "root:plu|commentary:sundara-lexical:V.1.9", "root:cal|commentary:sundara-lexical:V.1.12", "root:dyut|commentary:sundara-lexical:V.1.53", "root:dyut|commentary:sundara-lexical:V.1.58", "root:ji|commentary:sundara-lexical:V.6.21", "root:lakz|commentary:sundara-lexical:V.7.14", "root:siD|commentary:sundara-lexical:V.9.30", "root:su|commentary:sundara-lexical:V.9.56", "root:gA|commentary:sundara-lexical:V.9.68", "root:f|commentary:sundara-lexical:V.9.73", "root:aj|commentary:sundara-lexical:V.10.5", "root:sru|commentary:sundara-lexical:V.10.14", "root:yaj|commentary:sundara-lexical:V.10.20", "root:as|commentary:sundara-lexical:V.12.3", "root:vad|commentary:sundara-lexical:V.12.10", "root:vid|commentary:sundara-lexical:V.12.10", "root:ci|commentary:sundara-lexical:V.12.15", "root:siD|commentary:sundara-lexical:V.13.8", "root:sTA|commentary:sundara-lexical:V.13.40", "root:hfz|commentary:sundara-lexical:V.14.2", "root:Suc|commentary:sundara-lexical:V.14.3", "root:DA|commentary:sundara-lexical:V.14.49", "root:ci|commentary:sundara-lexical:V.15.16", "root:sad|commentary:sundara-lexical:V.15.16", "root:ruh|commentary:sundara-lexical:V.15.22", "root:Bf|commentary:sundara-lexical:V.17.21", "root:vad|commentary:sundara-lexical:V.18.3", "root:vyaD|commentary:sundara-lexical:V.18.23", "root:kf|commentary:sundara-lexical:V.19.10", "root:Df|commentary:sundara-lexical:V.20.5", "root:SI|commentary:sundara-lexical:V.20.26", "root:vf|commentary:sundara-lexical:V.21.27", "root:sf|commentary:sundara-lexical:V.22.3", "root:vft|commentary:sundara-lexical:V.22.12", "root:sic|commentary:sundara-lexical:V.23.11", "root:aS|commentary:sundara-lexical:V.24.47", "root:piS|commentary:sundara-lexical:V.24.47", "root:gad|commentary:sundara-lexical:V.25.2", "root:ji|commentary:sundara-lexical:V.26.47", "root:lok|commentary:sundara-lexical:V.28.6", "root:ruc|commentary:sundara-lexical:V.28.6", "root:SAs|commentary:sundara-lexical:V.32.9", "root:gA|commentary:sundara-lexical:V.34.6", "root:guh|commentary:sundara-lexical:V.35.15", "root:Sap|commentary:sundara-lexical:V.36.38", "root:Baj|commentary:sundara-lexical:V.36.41", "root:kf|commentary:sundara-lexical:V.37.3", "root:BU|commentary:sundara-lexical:V.37.33", "root:yat|commentary:sundara-lexical:V.37.60", "root:i|commentary:sundara-lexical:V.38.21", "root:Sak|commentary:sundara-lexical:V.38.27", "root:tap|commentary:sundara-lexical:V.39.23", "root:pad|commentary:sundara-lexical:V.39.33", "root:jYA|commentary:sundara-lexical:V.40.4", "root:ah|commentary:sundara-lexical:V.42.9", "root:i|commentary:sundara-lexical:V.42.9", "root:kf|commentary:sundara-lexical:V.42.24", "root:Df|commentary:sundara-lexical:V.43.18", "root:tap|commentary:sundara-lexical:V.45.12", "root:vf|commentary:sundara-lexical:V.46.1", "root:vid|commentary:sundara-lexical:V.46.27", "root:car|commentary:sundara-lexical:V.47.5", "root:saYj|commentary:sundara-lexical:V.47.5", "root:cal|commentary:sundara-lexical:V.47.13", "root:BU|commentary:sundara-lexical:V.47.20", "root:vfD|commentary:sundara-lexical:V.47.29", "root:rakz|commentary:sundara-lexical:V.48.1", "root:ru|commentary:sundara-lexical:V.50.1", "root:diS|commentary:sundara-lexical:V.51.2", "root:kIrt|commentary:sundara-lexical:V.51.23", "root:DA|commentary:sundara-lexical:V.53.1", "root:aS|commentary:sundara-lexical:V.53.26", "root:hu|commentary:sundara-lexical:V.53.26", "root:aYj|commentary:sundara-lexical:V.54.37", "root:aj|commentary:sundara-lexical:V.54.37", "root:riz|commentary:sundara-lexical:V.56.26", "root:Sak|commentary:sundara-lexical:V.56.44", "root:yuD|commentary:sundara-lexical:V.56.44", "root:vI|commentary:sundara-lexical:V.57.39", "root:tap|commentary:sundara-lexical:V.59.3", "root:as|commentary:sundara-lexical:V.59.10", "root:liK|commentary:sundara-lexical:V.59.22", "root:pad|commentary:sundara-lexical:V.59.31", "root:vft|commentary:sundara-lexical:V.61.5", "root:vac|commentary:sundara-lexical:V.61.20", "root:sfj|commentary:sundara-lexical:V.62.7", "root:dA|commentary:sundara-lexical:V.62.17", "root:vf|commentary:sundara-lexical:V.62.17", "root:f|commentary:sundara-lexical:V.62.26", "root:aYj|commentary:sundara-lexical:V.62.38", "root:Sak|commentary:sundara-lexical:V.63.32", "root:dfp|commentary:sundara-lexical:V.63.32", "root:jYA|commentary:sundara-lexical:V.64.6", "root:car|commentary:sundara-lexical:V.64.10", "root:tarj|commentary:sundara-lexical:V.65.3", "root:uc|commentary:sundara-lexical:V.66.13", "root:pat|commentary:sundara-lexical:V.67.10", "root:vf|commentary:sundara-lexical:V.67.10", "root:BAz|commentary:sundara-lexical:V.67.33", "root:sAD|commentary:sundara-lexical:V.68.11", "root:aYj|commentary:sundara-lexical:V.1.15", "root:Df|commentary:sundara-lexical:V.1.201", "root:yuj|commentary:sundara-lexical:V.2.3", "root:kf|commentary:sundara-lexical:V.2.16", "root:su|commentary:sundara-lexical:V.6.42", "root:yuj|commentary:sundara-lexical:V.9.2", "root:DU|commentary:sundara-lexical:V.9.27", "root:tap|commentary:sundara-lexical:V.11.4", "root:Suc|commentary:sundara-lexical:V.12.25", "root:cit|commentary:sundara-lexical:V.12.25", "root:kf|commentary:sundara-lexical:V.13.1", "root:pat|commentary:sundara-lexical:V.13.5", "root:vA|commentary:sundara-lexical:V.13.7", "root:jYA|commentary:sundara-lexical:V.13.28", "root:kf|commentary:sundara-lexical:V.13.28", "root:ru|commentary:sundara-lexical:V.13.29", "root:tF|commentary:sundara-lexical:V.13.30", "root:vas|commentary:sundara-lexical:V.13.56", "root:ac|commentary:sundara-lexical:V.14.4", "root:lI|commentary:sundara-lexical:V.14.52", "root:vas|commentary:sundara-lexical:V.15.19", "root:Bf|commentary:sundara-lexical:V.15.41", "root:kf|commentary:sundara-lexical:V.15.49", "root:sTA|commentary:sundara-lexical:V.15.52", "root:so|commentary:sundara-lexical:V.16.4", "root:kal|commentary:sundara-lexical:V.16.14", "root:Bf|commentary:sundara-lexical:V.16.19", "root:pA|commentary:sundara-lexical:V.16.22", "root:BUz|commentary:sundara-lexical:V.16.26", "root:hfz|commentary:sundara-lexical:V.17.17", "root:kzE|commentary:sundara-lexical:V.17.30", "root:sraMs|commentary:sundara-lexical:V.18.4", "root:vij|commentary:sundara-lexical:V.18.11", "root:DU|commentary:sundara-lexical:V.18.31", "root:jYA|commentary:sundara-lexical:V.19.11", "root:luB|commentary:sundara-lexical:V.21.11", "root:Sap|commentary:sundara-lexical:V.21.24", "root:vf|commentary:sundara-lexical:V.22.33", "root:Sru|commentary:sundara-lexical:V.23.7", "root:vfz|commentary:sundara-lexical:V.23.17", "root:f|commentary:sundara-lexical:V.23.18", "root:Buj|commentary:sundara-lexical:V.24.4", "root:vaD|commentary:sundara-lexical:V.28.5", "root:vid|commentary:sundara-lexical:V.28.17", "root:DI|commentary:sundara-lexical:V.28.20", "root:i|commentary:sundara-lexical:V.29.8", "root:vI|commentary:sundara-lexical:V.29.8", "root:car|commentary:sundara-lexical:V.30.4", "root:guh|commentary:sundara-lexical:V.30.4", "root:kf|commentary:sundara-lexical:V.30.17", "root:vac|commentary:sundara-lexical:V.30.17", "root:i|commentary:sundara-lexical:V.30.37", "root:kf|commentary:sundara-lexical:V.30.41", "root:BU|commentary:sundara-lexical:V.30.44", "root:dF|commentary:sundara-lexical:V.31.3", "root:vft|commentary:sundara-lexical:V.31.3", "root:tap|commentary:sundara-lexical:V.31.7", "root:DA|commentary:sundara-lexical:V.31.8", "root:piYj|commentary:sundara-lexical:V.32.1", "root:svap|commentary:sundara-lexical:V.32.3", "root:vac|commentary:sundara-lexical:V.32.14", "root:ruh|commentary:sundara-lexical:V.33.7", "root:dA|commentary:sundara-lexical:V.33.22", "root:car|commentary:sundara-lexical:V.35.12", "root:BA|commentary:sundara-lexical:V.35.37", "root:i|commentary:sundara-lexical:V.35.58", "root:pat|commentary:sundara-lexical:V.35.64", "root:DU|commentary:sundara-lexical:V.35.72", "root:BU|commentary:sundara-lexical:V.35.90", "root:uc|commentary:sundara-lexical:V.36.21", "root:hi|commentary:sundara-lexical:V.36.28", "root:DyE|commentary:sundara-lexical:V.36.43", "root:DA|commentary:sundara-lexical:V.37.4", "root:dA|commentary:sundara-lexical:V.37.10", "root:kf|commentary:sundara-lexical:V.37.18", "root:su|commentary:sundara-lexical:V.38.11", "root:IS|commentary:sundara-lexical:V.38.55", "root:sev|commentary:sundara-lexical:V.38.59", "root:pat|commentary:sundara-lexical:V.38.65", "root:sah|commentary:sundara-lexical:V.39.3", "root:aYj|commentary:sundara-lexical:V.39.6", "root:ruD|commentary:sundara-lexical:V.39.9", "root:Suc|commentary:sundara-lexical:V.40.24", "root:vij|commentary:sundara-lexical:V.40.24", "root:hu|commentary:sundara-lexical:V.42.22", "root:ji|commentary:sundara-lexical:V.42.33", "root:as|commentary:sundara-lexical:V.43.8", "root:vid|commentary:sundara-lexical:V.43.8", "root:f|commentary:sundara-lexical:V.44.2", "root:ji|commentary:sundara-lexical:V.44.2", "root:cal|commentary:sundara-lexical:V.46.17", "root:siD|commentary:sundara-lexical:V.46.17", "root:yuD|commentary:sundara-lexical:V.46.17", "root:grah|commentary:sundara-lexical:V.47.4", "root:rAD|commentary:sundara-lexical:V.48.2", "root:DA|commentary:sundara-lexical:V.48.4", "root:Df|commentary:sundara-lexical:V.48.13", "root:dfS|commentary:sundara-lexical:V.48.44", "root:as|commentary:sundara-lexical:V.48.48", "root:yuj|commentary:sundara-lexical:V.49.3", "root:tij|commentary:sundara-lexical:V.50.8", "root:Buj|commentary:sundara-lexical:V.51.20", "root:tap|commentary:sundara-lexical:V.51.40", "root:kruD|commentary:sundara-lexical:V.52.1", "root:ruz|commentary:sundara-lexical:V.53.9", "root:arc|commentary:sundara-lexical:V.53.44", "root:tfp|commentary:sundara-lexical:V.54.5", "root:kzi|commentary:sundara-lexical:V.54.24", "root:BaYj|commentary:sundara-lexical:V.54.25", "root:sah|commentary:sundara-lexical:V.54.25", "root:DA|commentary:sundara-lexical:V.54.26", "root:Sap|commentary:sundara-lexical:V.54.41", "root:vA|commentary:sundara-lexical:V.54.49", "root:vap|commentary:sundara-lexical:V.54.49", "root:kup|commentary:sundara-lexical:V.55.3", "root:as|commentary:sundara-lexical:V.55.12", "root:tij|commentary:sundara-lexical:V.55.22", "root:hu|commentary:sundara-lexical:V.55.24", "root:vah|commentary:sundara-lexical:V.55.24", "root:as|commentary:sundara-lexical:V.55.28", "root:vac|commentary:sundara-lexical:V.55.28", "root:diS|commentary:sundara-lexical:V.56.1", "root:Baj|commentary:sundara-lexical:V.56.4", "root:ruh|commentary:sundara-lexical:V.56.20", "root:Df|commentary:sundara-lexical:V.56.50", "root:tF|commentary:sundara-lexical:V.57.5", "root:Dav|commentary:sundara-lexical:V.57.9", "root:aYc|commentary:sundara-lexical:V.57.14", "root:dA|commentary:sundara-lexical:V.57.46", "root:jIv|commentary:sundara-lexical:V.57.46", "root:Df|commentary:sundara-lexical:V.57.47", "root:kf|commentary:sundara-lexical:V.58.115", "root:vaD|commentary:sundara-lexical:V.58.149", "root:as|commentary:sundara-lexical:V.59.5", "root:Baj|commentary:sundara-lexical:V.59.32", "root:pA|commentary:sundara-lexical:V.60.2", "root:div|commentary:sundara-lexical:V.60.8", "root:jYA|commentary:sundara-lexical:V.60.17", "root:sfj|commentary:sundara-lexical:V.61.12", "root:sU|commentary:sundara-lexical:V.61.13", "root:Dfz|commentary:sundara-lexical:V.61.23", "root:aMS|commentary:sundara-lexical:V.62.35", "root:su|commentary:sundara-lexical:V.62.35", "root:BI|commentary:sundara-lexical:V.63.2", "root:so|commentary:sundara-lexical:V.63.21", "root:sad|commentary:sundara-lexical:V.64.16", "root:hfz|commentary:sundara-lexical:V.64.29", "root:kf|commentary:sundara-lexical:V.65.2", "root:vft|commentary:sundara-lexical:V.65.6", "root:Baj|commentary:sundara-lexical:V.65.18", "root:vft|commentary:sundara-lexical:V.67.2", "root:kf|commentary:sundara-lexical:V.67.23", "root:Baj|commentary:sundara-lexical:V.68.4", "root:pac|commentary:sundara-lexical:V.68.4", "root:DA|commentary:sundara-lexical:V.68.13", "root:kfz|commentary:sundara-lexical:V.68.22"];
+  var state = {};
+  try { state = JSON.parse(localStorage.getItem(STORE_KEY) || '{}') || {}; } catch (e) { state = {}; }
+  function tally() {
+    var c = { approve:0, reject:0, defer:0 };
+    ids.forEach(function (id) { var v = state[id] && state[id].decision; if (v && c.hasOwnProperty(v)) c[v]++; });
+    document.getElementById('c-approve').textContent = c.approve;
+    document.getElementById('c-reject').textContent = c.reject;
+    document.getElementById('c-defer').textContent = c.defer;
+    document.getElementById('c-unvoted').textContent = ids.length - c.approve - c.reject - c.defer;
+  }
+  function applyCardUI(card) {
+    var id = card.getAttribute('data-id'); var rec = state[id] || {};
+    card.classList.remove('voted-approve','voted-reject','voted-defer');
+    card.querySelectorAll('button.vote').forEach(function (b) { b.classList.toggle('active', b.getAttribute('data-vote') === rec.decision); });
+    card.querySelector('.vote-state').textContent = rec.decision ? rec.decision : 'unvoted';
+    if (rec.decision) card.classList.add('voted-' + rec.decision);
+    var ta = card.querySelector('textarea.note'); if (rec.note && !ta.value) ta.value = rec.note;
+  }
+  function save() { localStorage.setItem(STORE_KEY, JSON.stringify(state)); tally(); }
+  // H1523 residual / csl-pyutil#1 Part 1: always re-read the live textarea on vote
+  // and before export so a second vote click (or a missed `input` event) cannot
+  // drop a note that is still visible in the card.
+  function syncNoteFromDom(id) {
+    state[id] = state[id] || {};
+    var card = document.querySelector('.card[data-id="' + id + '"]');
+    if (!card) return;
+    var ta = card.querySelector('textarea.note');
+    if (ta) state[id].note = ta.value;
+  }
+  function vote(id, d) { syncNoteFromDom(id); state[id].decision = d; save(); }
+  function noteChange(id, t) { state[id] = state[id] || {}; state[id].note = t; save(); }
+  document.querySelectorAll('.card').forEach(function (card) {
+    var id = card.getAttribute('data-id'); applyCardUI(card);
+    card.querySelectorAll('button.vote').forEach(function (btn) {
+      btn.addEventListener('click', function () { vote(id, btn.getAttribute('data-vote')); applyCardUI(card); });
+    });
+    var ta = card.querySelector('textarea.note'); ta.addEventListener('input', function () { noteChange(id, ta.value); });
+  });
+  tally();
+  document.getElementById('downloadBtn').addEventListener('click', function () {
+    ids.forEach(function (id) { syncNoteFromDom(id); });
+    var decided = ids.filter(function (id) { return state[id] && state[id].decision; }).length;
+    var payload = { sheet_id: SHEET_ID, generated: "26-08-2026", decided: decided, time_total_seconds: __timeTotal(),
+      items: ids.map(function (id) { var rec = state[id] || {}; return { id: id, decision: rec.decision || null, note: rec.note || '', time_seconds: __timeFor(id) }; }) };
+    var blob = new Blob([JSON.stringify(payload, null, 2)], { type:'application/json' });
+    var url = URL.createObjectURL(blob); var a = document.createElement('a');
+    a.href = url; a.download = SHEET_ID + '_decisions.json'; document.body.appendChild(a); a.click();
+    document.body.removeChild(a); URL.revokeObjectURL(url);
+  });
+  var filterbar = document.getElementById('filterbar');
+  filterbar.addEventListener('click', function (e) {
+    var btn = e.target.closest('button[data-filter]'); if (!btn) return;
+    filterbar.querySelectorAll('button').forEach(function (b) { b.classList.remove('active'); });
+    btn.classList.add('active'); var f = btn.getAttribute('data-filter');
+    document.querySelectorAll('.card').forEach(function (card) {
+      var show = true;
+      if (f === 'unvoted') { var id = card.getAttribute('data-id'); show = !(state[id] && state[id].decision); }
+      else if (f !== 'all') { show = card.getAttribute('data-filt') === f; }
+      card.style.display = show ? '' : 'none';
+    });
+  });
+  var cardsEl = Array.prototype.slice.call(document.querySelectorAll('.card'));
+  var activeIdx = 0;
+  function visibleCards() { return cardsEl.filter(function (c) { return c.style.display !== 'none'; }); }
+  document.addEventListener('keydown', function (e) {
+    if (e.target.tagName === 'TEXTAREA') return;
+    var vis = visibleCards(); if (!vis.length) return;
+    if (activeIdx >= vis.length) activeIdx = vis.length - 1;
+    var card = vis[activeIdx]; var id = card.getAttribute('data-id');
+    if (e.key === 'a') { vote(id, 'approve'); applyCardUI(card); }
+    else if (e.key === 'r') { vote(id, 'reject'); applyCardUI(card); }
+    else if (e.key === 'd') { vote(id, 'defer'); applyCardUI(card); }
+    else if (e.key === 'ArrowDown') { activeIdx = Math.min(activeIdx + 1, vis.length - 1); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else if (e.key === 'ArrowUp') { activeIdx = Math.max(activeIdx - 1, 0); vis[activeIdx].scrollIntoView({behavior:'smooth',block:'start'}); }
+    else return;
+    e.preventDefault();
+  });
+
+  var saveHandle = null, saveTimer = null;
+  function exportPayload() {
+    if (typeof syncNoteFromDom === 'function') {
+      ids.forEach(function (id) { syncNoteFromDom(id); });
+    }
+    var decided = ids.filter(function (id) { return state[id] && state[id].decision; }).length;
+    return JSON.stringify({ sheet_id: SHEET_ID, generated: new Date().toISOString(), decided: decided, time_total_seconds: __timeTotal(),
+      items: ids.map(function (id) { var rec = state[id] || {}; return { id: id, decision: rec.decision || null, note: rec.note || '', time_seconds: __timeFor(id) }; }) }, null, 2);
+  }
+  function scheduleAutosave() {
+    if (!saveHandle) return;
+    clearTimeout(saveTimer);
+    saveTimer = setTimeout(function () {
+      saveHandle.createWritable().then(function (w) {
+        w.write(exportPayload()).then(function () { w.close(); });
+      }).catch(function () {});
+    }, 1000);
+  }
+  var _origSave = save;
+  save = function () { _origSave(); scheduleAutosave(); };
+  if (window.showSaveFilePicker) {
+    var saveBtn = document.getElementById('saveBtn');
+    saveBtn.style.display = '';
+    saveBtn.addEventListener('click', function () {
+      window.showSaveFilePicker({suggestedName: SHEET_ID + '_decisions.json'}).then(function (h) {
+        saveHandle = h; scheduleAutosave();
+      }).catch(function () {});
+    });
+  }
+
+  var FS_KEY = STORE_KEY + ':fs', FS_DEFAULT = 1.5;
+  function fsGet() {
+    var v = parseFloat(localStorage.getItem(FS_KEY));
+    return (isFinite(v) && v >= 0.7 && v <= 3) ? v : FS_DEFAULT;
+  }
+  function fsApply(v) {
+    document.documentElement.style.setProperty('--fs', String(v));
+    document.getElementById('fsVal').textContent = Math.round(v * 100) + '%';
+  }
+  function fsSet(v) {
+    v = Math.min(3, Math.max(0.7, Math.round(v * 10) / 10));
+    localStorage.setItem(FS_KEY, String(v)); fsApply(v);
+  }
+  fsApply(fsGet());
+  document.getElementById('fsDown').addEventListener('click', function () { fsSet(fsGet() - 0.1); });
+  document.getElementById('fsUp').addEventListener('click', function () { fsSet(fsGet() + 0.1); });
+
+  var TIME_KEY = STORE_KEY + ':timing';
+  var __timing = { total: 0, per: {} };
+  try {
+    var __t0 = JSON.parse(localStorage.getItem(TIME_KEY) || 'null');
+    if (__t0 && typeof __t0.total === 'number') __timing = __t0;
+  } catch (e) {}
+  if (!__timing.per) __timing.per = {};
+  function __timeFor(id) { return Math.round(__timing.per[id] || 0); }
+  function __timeTotal() { return Math.round(__timing.total || 0); }
+  function __timeFmt(s) {
+    s = Math.round(s); var m = Math.floor(s / 60);
+    return (m >= 60 ? Math.floor(m / 60) + ':' + ('0' + (m - Math.floor(m / 60) * 60)).slice(-2) : m)
+      + ':' + ('0' + (s - m * 60)).slice(-2);
+  }
+  function __timeShow() {
+    var el = document.getElementById('t-total');
+    if (el) el.textContent = __timeFmt(__timing.total);
+  }
+  var __timeLast = Date.now(), __timeDirty = 0;
+  var __timeCards = Array.prototype.slice.call(document.querySelectorAll('.card'));
+  function __timeActiveId() {
+    var mid = window.innerHeight / 2, best = null, bestd = Infinity;
+    for (var i = 0; i < __timeCards.length; i++) {
+      var c = __timeCards[i];
+      if (c.style.display === 'none') continue;
+      var r = c.getBoundingClientRect();
+      if (r.bottom < 0 || r.top > window.innerHeight) continue;
+      var center = (Math.max(r.top, 0) + Math.min(r.bottom, window.innerHeight)) / 2;
+      var d = Math.abs(center - mid);
+      if (d < bestd) { bestd = d; best = c; }
+    }
+    return best ? best.getAttribute('data-id') : null;
+  }
+  function __timeFlush() {
+    try { localStorage.setItem(TIME_KEY, JSON.stringify(__timing)); } catch (e) {}
+  }
+  // V12 (H2858): the clock is stoppable. `paused` rides in the same persisted
+  // record as the totals, so a reviewer who pauses and closes the tab does not
+  // come back to a clock that ran all night.
+  var __timePaused = !!__timing.paused;
+  // V15 (H2887): a legacy record carries `paused` and no reason — read it as
+  // manual, so an auto-rearm can never lift a pause the curator set by hand.
+  var __timePauseReason = __timePaused ? (__timing.pause_reason || 'manual') : null;
+  function __timePauseSet(v, reason) {
+    __timePaused = !!v;
+    __timing.paused = __timePaused;
+    __timePauseReason = __timePaused ? (reason || 'manual') : null;
+    __timing.pause_reason = __timePauseReason;
+    __timeLast = Date.now(); __timeFlush();
+  }
+  setInterval(function () {
+    var now = Date.now(), dt = (now - __timeLast) / 1000;
+    __timeLast = now;
+    if (document.hidden || __timePaused || dt <= 0 || dt > 4) return;
+    __timing.total += dt;
+    var id = __timeActiveId();
+    if (id) __timing.per[id] = (__timing.per[id] || 0) + dt;
+    __timeDirty += dt;
+    if (__timeDirty >= 5) { __timeDirty = 0; __timeFlush(); }
+    __timeShow();
+  }, 1000);
+  document.addEventListener('visibilitychange', function () { __timeLast = Date.now(); });
+  window.addEventListener('beforeunload', __timeFlush);
+  __timeShow();
+
+  var HANDIN_SAID = 'handed in {n} of {total} — clock stopped, the rest stay saved in this browser';
+  var __handinBtn = document.getElementById('handinBtn');
+  var __handinSaid = document.getElementById('handinSaid');
+
+  var __pauseBtn = document.getElementById('pauseBtn');
+  function __pauseShow() {
+    __pauseBtn.classList.toggle('on', __timePaused);
+    __pauseBtn.innerHTML = __timePaused ? '&#9654;' : '&#9208;';
+    var chip = document.querySelector('.tally .time');
+    if (chip) chip.classList.toggle('paused', __timePaused);
+  }
+  __pauseBtn.addEventListener('click', function () { __timePauseSet(!__timePaused); __pauseShow(); });
+  __pauseShow();
+  __handinBtn.addEventListener('click', function () {
+    ids.forEach(function (id) { syncNoteFromDom(id); });
+    __timePauseSet(true, 'export'); __pauseShow();
+    var items = ids.map(function (id) {
+      var rec = state[id] || {};
+      var item = { id: id, decision: rec.decision || null };
+      item.note = rec.note || '';
+      item.time_seconds = __timeFor(id);
+      return item;
+    });
+    var decided = items.filter(function (it) { return !!it.decision; }).length;
+    var payload = { sheet_id: SHEET_ID, generated: GENERATED, decided: decided,
+      partial: true, complete: false, undecided: items.length - decided, items: items };
+    payload.time_total_seconds = __timeTotal();
+    var blob = new Blob([JSON.stringify(payload, null, 2)], { type:'application/json' });
+    var url = URL.createObjectURL(blob); var a = document.createElement('a');
+    a.href = url; a.download = SHEET_ID + '_decisions_partial.json';
+    document.body.appendChild(a); a.click();
+    document.body.removeChild(a); URL.revokeObjectURL(url);
+    __handinSaid.textContent = HANDIN_SAID.replace('{n}', decided).replace('{total}', items.length);
+  });
+
+  // --- V15 session flow (H2887) ---------------------------------------------
+  var FLOW_IDLE_SECONDS = 90;
+  var FLOW_ETA = 'about {minutes} min left';
+  var FLOW_ETA_ROUGH = 'about {minutes} min left (rough)';
+  var FLOW_CLOCK_RUNNING = 'running';
+  var FLOW_CLOCK_PAUSED = 'paused';
+  var FLOW_CLOCK_IDLE = 'idle';
+  var FLOW_PROGRESS = 'decided {n} of {total}';
+  var FLOW_UNDO_SAID = 'undo: {id} back to {decision}';
+  var FLOW_UNDO_EMPTY = 'nothing to undo';
+  var FLOW_UNDO_NONE = 'no decision';
+  var FLOW_RESUMED = 'resumed at card {n} of {total}';
+  var __flowToast = document.getElementById('flowToast');
+  var __flowToastTimer = null;
+  function __flowSay(text) {
+    if (!__flowToast) return;
+    __flowToast.textContent = text;
+    __flowToast.classList.add('on');
+    clearTimeout(__flowToastTimer);
+    __flowToastTimer = setTimeout(function () { __flowToast.classList.remove('on'); }, 2600);
+  }
+  var __flowCenterId = __timeActiveId;
+  function __flowIdxOf(id) {
+    var vis = visibleCards();
+    for (var i = 0; i < vis.length; i++) {
+      if (vis[i].getAttribute('data-id') === id) return i;
+    }
+    return -1;
+  }
+  function __flowCardById(id) {
+    var found = null;
+    cardsEl.forEach(function (c) { if (c.getAttribute('data-id') === id) found = c; });
+    return found;
+  }
+  // The visible ring IS the target of a/r/d — that identity is the whole point
+  // of this layer, so nothing may move `activeIdx` without repainting.
+  function __flowPaint() {
+    cardsEl.forEach(function (c) { c.classList.remove('kbd-active'); });
+    var vis = visibleCards();
+    if (!vis.length) return;
+    if (activeIdx >= vis.length) activeIdx = vis.length - 1;
+    if (activeIdx < 0) activeIdx = 0;
+    vis[activeIdx].classList.add('kbd-active');
+  }
+  function __flowSync() {
+    var id = __flowCenterId();
+    if (id) { var at = __flowIdxOf(id); if (at !== -1) activeIdx = at; }
+    __flowPaint();
+  }
+  var __flowScrollTimer = null;
+  window.addEventListener('scroll', function () {
+    if (__flowScrollTimer) return;
+    __flowScrollTimer = setTimeout(function () { __flowScrollTimer = null; __flowSync(); }, 120);
+  });
+  // Both bars reset `activeIdx` to 0 as they re-filter; re-derive it from the
+  // viewport on the next tick, or defect 2 returns wearing a filter.
+  ['filterbar'].forEach(function (barId) {
+    var bar = document.getElementById(barId);
+    if (bar) bar.addEventListener('click', function () { setTimeout(__flowSync, 0); });
+  });
+  function __flowClockShow() {
+    var el = document.getElementById('t-state');
+    if (!el) return;
+    var label = FLOW_CLOCK_RUNNING;
+    if (__timePaused) label = (__timePauseReason === 'idle') ? FLOW_CLOCK_IDLE : FLOW_CLOCK_PAUSED;
+    el.textContent = label;
+    el.classList.toggle('idle', !!__timePaused && __timePauseReason === 'idle');
+  }
+  // The V12 ⏸ button drives the clock straight through __timePauseSet, so the
+  // three-state label has to ride along with V12's own repaint or it goes stale
+  // the moment the curator pauses by hand.
+  var __flowOrigPauseShow = __pauseShow;
+  __pauseShow = function () { __flowOrigPauseShow(); __flowClockShow(); };
+  var __flowIdleTimer = null;
+  function __flowIdleArm() {
+    clearTimeout(__flowIdleTimer);
+    __flowIdleTimer = setTimeout(function () {
+      if (__timePaused) return;
+      __timePauseSet(true, 'idle');
+    __pauseShow();
+      __flowClockShow();
+    }, FLOW_IDLE_SECONDS * 1000);
+  }
+  function __flowRearm() {
+    if (__timePaused && __timePauseReason !== 'manual') {
+      __timePauseSet(false);
+    __pauseShow();
+    }
+    __flowClockShow();
+    __flowIdleArm();
+  }
+  // The export GESTURES, caught in the capture phase on `document` so this runs
+  // before any handler bound to the buttons themselves — including the strict
+  // layer's, which calls stopImmediatePropagation() on its own element.
+  document.addEventListener('click', function (e) {
+    var t = e.target;
+    if (!t || !t.closest || !t.closest('#downloadBtn, #saveBtn, #handinBtn')) return;
+    __timePauseSet(true, 'export');
+    __pauseShow();
+    __flowClockShow();
+  }, true);
+  ['keydown', 'pointerdown', 'scroll'].forEach(function (evt) {
+    document.addEventListener(evt, function () { __flowRearm(); }, true);
+  });
+  var __flowUndoStack = [];
+  function __flowUndo() {
+    var last = __flowUndoStack.pop();
+    if (!last) { __flowSay(FLOW_UNDO_EMPTY); return; }
+    state[last.id] = state[last.id] || {};
+    if (last.prev) state[last.id].decision = last.prev;
+    else delete state[last.id].decision;
+    save();
+    var card = __flowCardById(last.id);
+    if (card) {
+      applyCardUI(card);
+      card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      var at = __flowIdxOf(last.id);
+      if (at !== -1) activeIdx = at;
+      __flowPaint();
+    }
+    __flowSay(FLOW_UNDO_SAID.replace('{id}', last.id)
+      .replace('{decision}', last.prev || FLOW_UNDO_NONE));
+  }
+  var __flowUndoBtn = document.getElementById('flowUndoBtn');
+  if (__flowUndoBtn) __flowUndoBtn.addEventListener('click', __flowUndo);
+  function __flowFirstUndecided() {
+    var vis = visibleCards();
+    for (var i = 0; i < vis.length; i++) {
+      var id = vis[i].getAttribute('data-id');
+      if (!(state[id] && state[id].decision)) return i;
+    }
+    return -1;
+  }
+  function __flowAdvance() {
+    var at = __flowFirstUndecided();
+    if (at === -1) { __flowPaint(); return; }
+    activeIdx = at;
+    visibleCards()[at].scrollIntoView({ behavior: 'smooth', block: 'start' });
+    __flowPaint();
+  }
+  function __flowDecided() {
+    var n = 0;
+    ids.forEach(function (id) { if (state[id] && state[id].decision) n++; });
+    return n;
+  }
+  function __flowEtaText(decided, total) {
+    var secs = [];
+    ids.forEach(function (id) {
+      if (!(state[id] && state[id].decision)) return;
+      var s = __timing.per[id] || 0;
+      if (s > 0) secs.push(s);
+    });
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var left = Math.max(0, total - decided);
+    if (!left) return '';
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? FLOW_ETA : FLOW_ETA_ROUGH).replace('{minutes}', minutes);
+  }
+  function __flowProgress() {
+    var n = __flowDecided(), total = ids.length;
+    var txt = document.getElementById('flowProgText');
+    if (txt) txt.textContent = FLOW_PROGRESS.replace('{n}', n).replace('{total}', total);
+    var bar = document.getElementById('flowBar');
+    if (bar) bar.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var etaEl = document.getElementById('flowEta');
+    if (etaEl) etaEl.textContent = __flowEtaText(n, total);
+  }
+  var __flowOrigTally = tally;
+  tally = function () { __flowOrigTally(); __flowProgress(); };
+  var __flowOrigVote = vote;
+  vote = function (id, d) {
+    var rec = state[id] || {};
+    __flowUndoStack.push({ id: id, prev: rec.decision || null });
+    if (__flowUndoStack.length > 100) __flowUndoStack.shift();
+    __flowOrigVote(id, d);
+    __flowRearm();
+    __flowAdvance();
+  };
+  var __flowOrigNote = noteChange;
+  noteChange = function (id, t) { __flowOrigNote(id, t); __flowRearm(); };
+  document.addEventListener('keydown', function (e) {
+    if (e.target.tagName === 'TEXTAREA') return;
+    if (e.key === 'z' || e.key === 'Z') { __flowUndo(); e.preventDefault(); return; }
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') __flowPaint();
+  });
+  __flowProgress();
+  __flowSync();
+  __flowClockShow();
+  __flowIdleArm();
+  (function () {
+    if (!__flowDecided()) return;
+    var at = __flowFirstUndecided();
+    if (at === -1) return;
+    var vis = visibleCards();
+    activeIdx = at;
+    vis[at].scrollIntoView({ block: 'start' });
+    __flowPaint();
+    __flowSay(FLOW_RESUMED.replace('{n}', at + 1).replace('{total}', vis.length));
+  })();
+
+  var VOTE_TOTAL = 0;
+  var VOTE_PROGRESS = '{n} of {total} across the whole sheet';
+  var VOTE_ETA = 'about {minutes} min left for all {total}';
+  var VOTE_ETA_ROUGH = 'about {minutes} min left for all {total} (rough)';
+  var VOTE_DONE = 'all {total} decided';
+  (function () {
+    var bar = document.getElementById('voteBar');
+    if (!bar) return;
+    // The build tagged exactly the submit controls this document actually has.
+    // Navigation (filters, facets, the type-scale control) is untagged and stays
+    // on top, where it is used BEFORE deciding.
+    var moved = document.querySelectorAll('[data-submit]');
+    for (var i = 0; i < moved.length; i++) bar.appendChild(moved[i]);
+  })();
+  // One record backs every pack of a packset — STORE_KEY and TIME_KEY are keyed
+  // on sheet_id, not on the pack — so this page can count and time the WHOLE
+  // instrument without loading a single other pack.
+  function __voteDecidedAll() {
+    var n = 0;
+    for (var k in state) {
+      if (Object.prototype.hasOwnProperty.call(state, k) && state[k] && state[k].decision) n++;
+    }
+    return n;
+  }
+  function __voteSecs() {
+    var per = (typeof __timing !== 'undefined' && __timing && __timing.per) ? __timing.per : null;
+    var out = [];
+    if (!per) return out;
+    for (var k in per) {
+      if (!Object.prototype.hasOwnProperty.call(per, k)) continue;
+      if (!(state[k] && state[k].decision)) continue;
+      if (per[k] > 0) out.push(per[k]);
+    }
+    return out;
+  }
+  function __voteEta(decided, total) {
+    var left = Math.max(0, total - decided);
+    if (!left) return VOTE_DONE.replace('{total}', total);
+    var secs = __voteSecs();
+    if (!secs.length) return '';
+    secs.sort(function (a, b) { return a - b; });
+    var mid = Math.floor(secs.length / 2);
+    var med = (secs.length % 2) ? secs[mid] : (secs[mid - 1] + secs[mid]) / 2;
+    var minutes = Math.max(1, Math.round(med * left / 60));
+    return (secs.length >= 5 ? VOTE_ETA : VOTE_ETA_ROUGH)
+      .replace('{minutes}', minutes).replace('{total}', total);
+  }
+  function __voteProgress() {
+    var total = VOTE_TOTAL || ids.length;
+    var n = VOTE_TOTAL ? __voteDecidedAll() : ids.filter(function (id) {
+      return state[id] && state[id].decision; }).length;
+    if (n > total) n = total;
+    var t = document.getElementById('voteProgText');
+    if (t) t.innerHTML = VOTE_PROGRESS.replace('{n}', '<b>' + n + '</b>')
+                                      .replace('{total}', '<b>' + total + '</b>');
+    var b = document.getElementById('voteProgBar');
+    if (b) b.style.width = (total ? Math.round(100 * n / total) : 0) + '%';
+    var e = document.getElementById('voteProgEta');
+    if (e) e.textContent = __voteEta(n, total);
+  }
+  var __voteOrigTally = tally;
+  tally = function () { __voteOrigTally(); __voteProgress(); };
+  __voteProgress();
+})();
+</script>
+<div class="flowtoast" id="flowToast" role="status"></div>
+</body>
+</html>


### PR DESCRIPTION
Q4.1 Type-D linkid pilot review sheet, 258 cards. Source: CommentaryStrategies PR #199 (merged). Registered in Uprava REVIEW_SHEETS_INDEX in the same pass.